### PR TITLE
Add ONNX export functionality and extensive converter implementations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e . pytest torch scikit-learn matplotlib
+          pip install -e . pytest torch scikit-learn matplotlib onnx onnxruntime
 
       - name: Run tests
         run: python -m pytest tests/ -q

--- a/marquetry/configuration.py
+++ b/marquetry/configuration.py
@@ -22,6 +22,10 @@ class Config(object):
 
     enable_backprop = True
     train = True
+    # When True, every function keeps all of its input data on the recorded graph
+    # even if the function declares it unnecessary for backprop.
+    # The ONNX export uses this to read constants back from the traced graph.
+    retain_graph_inputs = False
     CUDA_ENABLE = cuda_backend.GPU_ENABLE
     CACHE_DIR = os.path.join(os.path.expanduser("~"), ".marquetry")
     MAX_SIZE = 1e+9

--- a/marquetry/function.py
+++ b/marquetry/function.py
@@ -111,7 +111,7 @@ class Function(object):
             self.outputs = tuple([weakref.ref(output.node) for output in outputs])
 
             input_indexes_to_retain = self._input_indexes_to_retain
-            if input_indexes_to_retain is None:
+            if input_indexes_to_retain is None or marquetry.configuration.config.retain_graph_inputs:
                 input_indexes_to_retain = range(len(inputs))
             for index in input_indexes_to_retain:
                 inputs[index].retain_data()

--- a/marquetry/functions/activations/gelu.py
+++ b/marquetry/functions/activations/gelu.py
@@ -35,8 +35,17 @@ class GELU(Function):
     def forward(self, x):
         xp = cuda_backend.get_array_module(x)
 
+        # NumPy scalars promote float32 arrays to float64, so align the constants
+        # with the input dtype to keep the output dtype unchanged.
+        if x.dtype.kind == "f":
+            def scalar(value):
+                return x.dtype.type(value)
+        else:
+            def scalar(value):
+                return value
+
         if self.approximate == "tanh":
-            tanh = xp.tanh(xp.sqrt(2 / xp.pi) * (x + 0.044715 * xp.power(x, 3)))
+            tanh = xp.tanh(scalar(np.sqrt(2 / np.pi)) * (x + 0.044715 * xp.power(x, 3)))
             y = 0.5 * x * (1 + tanh)
 
             self.tanh = tanh
@@ -49,9 +58,9 @@ class GELU(Function):
 
         else:
             if xp is np:
-                gauss = (1 + scipy.special.erf(x / xp.sqrt(2))) / 2
+                gauss = (1 + scipy.special.erf(x / scalar(np.sqrt(2)))) / 2
             else:
-                gauss = (1 + cuda_backend.cpx.scipy.special.erf(x / xp.sqrt(2))) / 2
+                gauss = (1 + cuda_backend.cpx.scipy.special.erf(x / scalar(np.sqrt(2)))) / 2
 
             y = x * gauss
 

--- a/marquetry/functions/pooling/max_pooling2d.py
+++ b/marquetry/functions/pooling/max_pooling2d.py
@@ -28,7 +28,16 @@ class MaxPooling2D(Function):
         self.input_shape = x.shape
         self.input_dtype = x.dtype
 
-        col = utils.im2col_array(x, self.kernel_size, self.stride, self.pad, to_matrix=False)
+        xp = cuda_backend.get_array_module(x)
+        # Pad with the lowest value so that padding never wins over real values,
+        # following the standard max pooling semantics (PyTorch/Chainer/ONNX).
+        if x.dtype.kind == "f":
+            pad_value = -xp.inf
+        else:
+            pad_value = xp.iinfo(x.dtype).min
+
+        col = utils.im2col_array(x, self.kernel_size, self.stride, self.pad,
+                                 to_matrix=False, pad_value=pad_value)
         batch_size, channels, kernel_height, kernel_weight, out_height, out_width = col.shape
         col = col.reshape((batch_size, channels, kernel_height * kernel_weight, out_height, out_width))
 

--- a/marquetry/functions/pooling/max_pooling2d.py
+++ b/marquetry/functions/pooling/max_pooling2d.py
@@ -33,6 +33,8 @@ class MaxPooling2D(Function):
         # following the standard max pooling semantics (PyTorch/Chainer/ONNX).
         if x.dtype.kind == "f":
             pad_value = -xp.inf
+        elif x.dtype.kind == "b":
+            pad_value = False
         else:
             pad_value = xp.iinfo(x.dtype).min
 

--- a/marquetry/layers/activations/dynamic_swish.py
+++ b/marquetry/layers/activations/dynamic_swish.py
@@ -40,10 +40,10 @@ class DynamicSwish(Layer):
 
     """
 
-    def __init__(self, init_beta=1.):
+    def __init__(self, init_beta=1., dtype=np.float32):
         super().__init__()
 
-        self.beta = Parameter(np.array(init_beta))
+        self.beta = Parameter(np.array(init_beta, dtype=dtype))
         self.init_check = False
 
     def forward(self, x):

--- a/marquetry/layers/activations/prelu.py
+++ b/marquetry/layers/activations/prelu.py
@@ -41,10 +41,10 @@ class PReLU(Layer):
                        [ 1.16250809e+00 -8.42350188e-04 -8.15572916e-03 -2.16238255e-05 6.29149104e-01]])
     """
 
-    def __init__(self, num_parameter=1, init=0.01):
+    def __init__(self, num_parameter=1, init=0.01, dtype=np.float32):
         super().__init__()
 
-        alpha = np.zeros(num_parameter) + init
+        alpha = np.zeros(num_parameter, dtype=dtype) + init
         self.alpha = Parameter(alpha)
 
     def forward(self, x):

--- a/marquetry/layers/array/convolution_2d.py
+++ b/marquetry/layers/array/convolution_2d.py
@@ -71,7 +71,7 @@ class Convolution2D(Layer):
         kernel_height, kernel_width = utils.pair(self.kernel_size)
 
         scale = xp.sqrt(1 / (channels * kernel_height * kernel_width))
-        w_data = xp.random.randn(output_channels, channels, kernel_height, kernel_width).astype(self.dtype) * scale
+        w_data = (xp.random.randn(output_channels, channels, kernel_height, kernel_width) * scale).astype(self.dtype)
 
         self.w.data = w_data
 

--- a/marquetry/layers/array/deconvolution_2d.py
+++ b/marquetry/layers/array/deconvolution_2d.py
@@ -73,7 +73,7 @@ class Deconvolution2D(Layer):
         channels, out_channels = self.in_channels, self.out_channels
         kernel_height, kernel_width = utils.pair(self.kernel_size)
         scale = xp.sqrt(1 / (channels * kernel_height * kernel_width))
-        w_data = xp.random.randn(channels, out_channels, kernel_height, kernel_width).astype(self.dtype) * scale
+        w_data = (xp.random.randn(channels, out_channels, kernel_height, kernel_width) * scale).astype(self.dtype)
         self.w.data = w_data
 
         if self.b is not None and xp is not np:

--- a/marquetry/layers/array/linear.py
+++ b/marquetry/layers/array/linear.py
@@ -55,7 +55,7 @@ class Linear(Layer):
 
     def _init_w(self, xp=np):
         in_size, out_size = self.in_size, self.outsize
-        w_data = xp.random.randn(in_size, out_size).astype(self.dtype) * xp.sqrt(1 / in_size)
+        w_data = (xp.random.randn(in_size, out_size) * xp.sqrt(1 / in_size)).astype(self.dtype)
         self.w.data = w_data
         if self.b is not None and xp is not np:
             self.b.to_gpu()

--- a/marquetry/model.py
+++ b/marquetry/model.py
@@ -18,3 +18,21 @@ class Model(Layer):
         y = self.forward(*inputs)
 
         return utils.plot_dot_graph(y, verbose=True, to_file=to_file)
+
+    def export_onnx(self, inputs, file_path=None, **kwargs):
+        """Export this model to an ONNX inference graph.
+
+            This requires the ``onnx`` package.
+            See :func:`marquetry.onnx_export.export_onnx` for the details and options.
+
+            Args:
+                inputs: A sample input array (or :class:`marquetry.Container`),
+                    or a tuple/list of them for multi-input models.
+                file_path (str or None): If given, the model is also serialized to this path.
+
+            Returns:
+                onnx.ModelProto: The exported model.
+        """
+        from marquetry.onnx_export import export_onnx
+
+        return export_onnx(self, inputs, file_path, **kwargs)

--- a/marquetry/onnx_export/__init__.py
+++ b/marquetry/onnx_export/__init__.py
@@ -1,0 +1,2 @@
+from marquetry.onnx_export.converters import ONNXExportError
+from marquetry.onnx_export.exporter import export_onnx

--- a/marquetry/onnx_export/converters.py
+++ b/marquetry/onnx_export/converters.py
@@ -157,10 +157,16 @@ def _convert_reshape(func, in_names, out_names, ctx):
         shape = (shape,)
     shape = [int(dim) for dim in shape]
 
-    # Keep the batch axis dynamic: a leading dim traced as the concrete batch size
-    # (e.g. flatten's `(batch, -1)`) is emitted as 0, which ONNX Reshape resolves
-    # to "copy the input dim" when allowzero=0.
-    if ctx.dynamic_batch and ctx.batch_size is not None and shape and shape[0] == ctx.batch_size:
+    # Keep the batch axis dynamic: substitute the leading dim with 0 ("copy the
+    # input dim") only when both the traced input and the target keep the batch
+    # extent in front, e.g. flatten's `(batch, -1)`. A reshape whose leading dim
+    # merely coincides with the batch size stays literal. Tracing with a batch
+    # size that doesn't collide with fixed reshape dims avoids the remaining
+    # ambiguity entirely.
+    x_shape = func.x_shape
+    if (ctx.dynamic_batch and ctx.batch_size is not None
+            and shape and shape[0] == ctx.batch_size
+            and x_shape is not None and len(x_shape) >= 1 and x_shape[0] == ctx.batch_size):
         shape[0] = 0
 
     shape_name = ctx.constant(np.asarray(shape, dtype=np.int64), "reshape_shape")
@@ -433,17 +439,78 @@ def _convert_softplus(func, in_names, out_names, ctx):
 
 @register("GELU")
 def _convert_gelu(func, in_names, out_names, ctx):
-    if func.approximate in ("none", "tanh"):
+    # The Gelu operator only exists since opset 20; decompose below that.
+    if func.approximate in ("none", "tanh") and ctx.opset_version >= 20:
         ctx.add_node("Gelu", in_names, out_names, approximate=func.approximate)
-        return
+    elif func.approximate == "none":
+        _emit_gelu_erf(func, in_names, out_names, ctx)
+    elif func.approximate == "tanh":
+        _emit_gelu_tanh(func, in_names, out_names, ctx)
+    else:
+        # The sigmoid approximation has no ONNX counterpart: x * sigmoid(1.702 * x)
+        scale_name = ctx.constant(np.asarray(1.702, dtype=_input_dtype(func)), "gelu_scale")
+        scaled = ctx.intermediate("gelu_scaled")
+        ctx.add_node("Mul", [in_names[0], scale_name], [scaled])
+        gate = ctx.intermediate("gelu_gate")
+        ctx.add_node("Sigmoid", [scaled], [gate])
+        ctx.add_node("Mul", [in_names[0], gate], out_names)
 
-    # The sigmoid approximation has no ONNX counterpart: x * sigmoid(1.702 * x)
-    scale_name = ctx.constant(np.asarray(1.702, dtype=_input_dtype(func)), "gelu_scale")
-    scaled = ctx.intermediate("gelu_scaled")
-    ctx.add_node("Mul", [in_names[0], scale_name], [scaled])
+
+def _emit_gelu_erf(func, in_names, out_names, ctx):
+    """Exact GELU as primitives: 0.5 * x * (1 + erf(x / sqrt(2)))."""
+    dtype = _input_dtype(func)
+
+    root_two = ctx.constant(np.asarray(np.sqrt(2.0), dtype=dtype), "gelu_root_two")
+    erf_input = ctx.intermediate("gelu_erf_input")
+    ctx.add_node("Div", [in_names[0], root_two], [erf_input])
+
+    erf = ctx.intermediate("gelu_erf")
+    ctx.add_node("Erf", [erf_input], [erf])
+
+    one = ctx.constant(np.asarray(1.0, dtype=dtype), "gelu_one")
     gate = ctx.intermediate("gelu_gate")
-    ctx.add_node("Sigmoid", [scaled], [gate])
-    ctx.add_node("Mul", [in_names[0], gate], out_names)
+    ctx.add_node("Add", [erf, one], [gate])
+
+    half = ctx.constant(np.asarray(0.5, dtype=dtype), "gelu_half")
+    half_x = ctx.intermediate("gelu_half_x")
+    ctx.add_node("Mul", [in_names[0], half], [half_x])
+
+    ctx.add_node("Mul", [half_x, gate], out_names)
+
+
+def _emit_gelu_tanh(func, in_names, out_names, ctx):
+    """Tanh-approximated GELU as primitives:
+        0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3)))
+    """
+    dtype = _input_dtype(func)
+
+    three = ctx.constant(np.asarray(3.0, dtype=dtype), "gelu_three")
+    cubed = ctx.intermediate("gelu_cubed")
+    ctx.add_node("Pow", [in_names[0], three], [cubed])
+
+    cubic_coeff = ctx.constant(np.asarray(0.044715, dtype=dtype), "gelu_cubic_coeff")
+    scaled_cube = ctx.intermediate("gelu_scaled_cube")
+    ctx.add_node("Mul", [cubed, cubic_coeff], [scaled_cube])
+
+    inner_sum = ctx.intermediate("gelu_inner_sum")
+    ctx.add_node("Add", [in_names[0], scaled_cube], [inner_sum])
+
+    coeff = ctx.constant(np.asarray(np.sqrt(2.0 / np.pi), dtype=dtype), "gelu_coeff")
+    inner = ctx.intermediate("gelu_inner")
+    ctx.add_node("Mul", [inner_sum, coeff], [inner])
+
+    tanh = ctx.intermediate("gelu_tanh")
+    ctx.add_node("Tanh", [inner], [tanh])
+
+    one = ctx.constant(np.asarray(1.0, dtype=dtype), "gelu_one")
+    gate = ctx.intermediate("gelu_gate")
+    ctx.add_node("Add", [tanh, one], [gate])
+
+    half = ctx.constant(np.asarray(0.5, dtype=dtype), "gelu_half")
+    half_x = ctx.intermediate("gelu_half_x")
+    ctx.add_node("Mul", [in_names[0], half], [half_x])
+
+    ctx.add_node("Mul", [half_x, gate], out_names)
 
 
 @register("GLU")

--- a/marquetry/onnx_export/converters.py
+++ b/marquetry/onnx_export/converters.py
@@ -1,0 +1,504 @@
+import numpy as np
+from onnx.helper import np_dtype_to_tensor_dtype
+
+from marquetry import utils
+
+
+class ONNXExportError(RuntimeError):
+    """Raised when a model contains a computation which can't be expressed in ONNX."""
+
+
+_CONVERTERS = {}
+
+
+def register(name):
+    """Register a converter for a :class:`marquetry.Function` subclass by its class name."""
+    def decorator(converter):
+        _CONVERTERS[name] = converter
+        return converter
+
+    return decorator
+
+
+def lookup(function_obj):
+    """Get the converter for a traced function instance, or None if unsupported."""
+    return _CONVERTERS.get(function_obj.__class__.__name__)
+
+
+def _input_dtype(func, index=0, default=np.float32):
+    dtype = func.inputs[index].dtype
+    return dtype if dtype is not None else np.dtype(default)
+
+
+def _cast_like_first_input(func, source_name, hint, ctx):
+    """Insert a Cast to the dtype of the function's first input when dtypes differ."""
+    x_dtype = func.inputs[0].dtype
+    other_dtype = func.inputs[1].dtype
+    if x_dtype is None or other_dtype is None or x_dtype == other_dtype:
+        return source_name
+
+    casted = ctx.intermediate(hint)
+    ctx.add_node("Cast", [source_name], [casted],
+                 to=np_dtype_to_tensor_dtype(np.dtype(x_dtype)))
+
+    return casted
+
+
+def _register_direct(marquetry_name, onnx_op):
+    def converter(func, in_names, out_names, ctx):
+        ctx.add_node(onnx_op, in_names, out_names)
+
+    _CONVERTERS[marquetry_name] = converter
+
+
+# ===========================================================================
+# math
+# ===========================================================================
+for _marquetry_name, _onnx_op in [
+    ("Add", "Add"), ("Sub", "Sub"), ("Mul", "Mul"), ("Div", "Div"),
+    ("Neg", "Neg"), ("Exp", "Exp"), ("Log", "Log"), ("Absolute", "Abs"),
+    ("Sqrt", "Sqrt"), ("Reciprocal", "Reciprocal"), ("MatMul", "MatMul"),
+]:
+    _register_direct(_marquetry_name, _onnx_op)
+
+
+@register("Pow")
+def _convert_pow(func, in_names, out_names, ctx):
+    exponent = ctx.constant(np.asarray(func.c, dtype=_input_dtype(func)), "pow_exponent")
+    ctx.add_node("Pow", [in_names[0], exponent], out_names)
+
+
+@register("Square")
+def _convert_square(func, in_names, out_names, ctx):
+    ctx.add_node("Mul", [in_names[0], in_names[0]], out_names)
+
+
+def _convert_log_base(base):
+    def converter(func, in_names, out_names, ctx):
+        natural_log = ctx.intermediate("natural_log")
+        ctx.add_node("Log", in_names, [natural_log])
+        denominator = ctx.constant(np.asarray(np.log(base), dtype=_input_dtype(func)), "log_base")
+        ctx.add_node("Div", [natural_log, denominator], out_names)
+
+    return converter
+
+
+_CONVERTERS["Log2"] = _convert_log_base(2.0)
+_CONVERTERS["Log10"] = _convert_log_base(10.0)
+
+
+@register("Clip")
+def _convert_clip(func, in_names, out_names, ctx):
+    dtype = _input_dtype(func)
+    inputs = [in_names[0]]
+    inputs.append(ctx.constant(np.asarray(func.x_min, dtype=dtype), "clip_min")
+                  if func.x_min is not None else "")
+    inputs.append(ctx.constant(np.asarray(func.x_max, dtype=dtype), "clip_max")
+                  if func.x_max is not None else "")
+    while inputs and inputs[-1] == "":
+        inputs.pop()
+    ctx.add_node("Clip", inputs, out_names)
+
+
+def _convert_reduce(onnx_op):
+    def converter(func, in_names, out_names, ctx):
+        axis = func.axis
+        inputs = [in_names[0]]
+        if axis is not None:
+            axes = (axis,) if isinstance(axis, int) else tuple(axis)
+            inputs.append(ctx.constant(np.asarray(axes, dtype=np.int64), "reduce_axes"))
+        ctx.add_node(onnx_op, inputs, out_names, keepdims=int(func.keepdims))
+
+    return converter
+
+
+_CONVERTERS["Sum"] = _convert_reduce("ReduceSum")
+_CONVERTERS["Max"] = _convert_reduce("ReduceMax")
+_CONVERTERS["Min"] = _convert_reduce("ReduceMin")
+_CONVERTERS["Average"] = _convert_reduce("ReduceMean")
+
+
+@register("SumTo")
+def _convert_sum_to(func, in_names, out_names, ctx):
+    target_shape = tuple(func.shape)
+    x_shape = func.x_shape
+    if x_shape is None or tuple(x_shape) == target_shape:
+        ctx.add_node("Identity", in_names, out_names)
+        return
+
+    lead = len(x_shape) - len(target_shape)
+    axes = list(range(lead))
+    axes += [k + lead for k, dim in enumerate(target_shape) if dim == 1 and x_shape[k + lead] != 1]
+
+    reduced = ctx.intermediate("sum_to_reduced")
+    axes_name = ctx.constant(np.asarray(axes, dtype=np.int64), "sum_to_axes")
+    ctx.add_node("ReduceSum", [in_names[0], axes_name], [reduced], keepdims=1)
+    shape_name = ctx.constant(np.asarray(target_shape, dtype=np.int64), "sum_to_shape")
+    ctx.add_node("Reshape", [reduced, shape_name], out_names)
+
+
+@register("BroadcastTo")
+def _convert_broadcast_to(func, in_names, out_names, ctx):
+    if func.x_shape is None:
+        ctx.add_node("Identity", in_names, out_names)
+        return
+
+    shape_name = ctx.constant(np.asarray(func.shape, dtype=np.int64), "expand_shape")
+    ctx.add_node("Expand", [in_names[0], shape_name], out_names)
+
+
+# ===========================================================================
+# array
+# ===========================================================================
+@register("Reshape")
+def _convert_reshape(func, in_names, out_names, ctx):
+    shape = func.shape
+    if isinstance(shape, (int, np.integer)):
+        shape = (shape,)
+    shape = [int(dim) for dim in shape]
+
+    # Keep the batch axis dynamic: a leading dim traced as the concrete batch size
+    # (e.g. flatten's `(batch, -1)`) is emitted as 0, which ONNX Reshape resolves
+    # to "copy the input dim" when allowzero=0.
+    if ctx.dynamic_batch and ctx.batch_size is not None and shape and shape[0] == ctx.batch_size:
+        shape[0] = 0
+
+    shape_name = ctx.constant(np.asarray(shape, dtype=np.int64), "reshape_shape")
+    ctx.add_node("Reshape", [in_names[0], shape_name], out_names)
+
+
+@register("Transpose")
+def _convert_transpose(func, in_names, out_names, ctx):
+    if func.axes is None:
+        ctx.add_node("Transpose", in_names, out_names)
+    else:
+        ctx.add_node("Transpose", in_names, out_names, perm=[int(axis) for axis in func.axes])
+
+
+@register("Concat")
+def _convert_concat(func, in_names, out_names, ctx):
+    ctx.add_node("Concat", in_names, out_names, axis=int(func.axis))
+
+
+@register("Squeeze")
+def _convert_squeeze(func, in_names, out_names, ctx):
+    inputs = [in_names[0]]
+    if func.axis is not None:
+        inputs.append(ctx.constant(np.asarray(func.axis, dtype=np.int64), "squeeze_axes"))
+    ctx.add_node("Squeeze", inputs, out_names)
+
+
+@register("UnSqueeze")
+def _convert_unsqueeze(func, in_names, out_names, ctx):
+    axes_name = ctx.constant(np.asarray(sorted(func.axis), dtype=np.int64), "unsqueeze_axes")
+    ctx.add_node("Unsqueeze", [in_names[0], axes_name], out_names)
+
+
+@register("Split")
+def _convert_split(func, in_names, out_names, ctx):
+    if isinstance(func.indices, (int, np.integer)):
+        ctx.add_node("Split", [in_names[0]], out_names,
+                     axis=int(func.axis), num_outputs=int(func.indices))
+        return
+
+    x_shape = func.inputs[0].shape
+    if x_shape is None:
+        raise ONNXExportError(
+            "Split with explicit indices requires the input shape, which was not recorded.")
+
+    total = x_shape[func.axis]
+    indices = [int(index) for index in func.indices]
+    sizes = [indices[0]]
+    sizes += [second - first for first, second in zip(indices, indices[1:])]
+    sizes.append(total - indices[-1])
+
+    sizes_name = ctx.constant(np.asarray(sizes, dtype=np.int64), "split_sizes")
+    ctx.add_node("Split", [in_names[0], sizes_name], out_names, axis=int(func.axis))
+
+
+@register("GetItem")
+def _convert_get_item(func, in_names, out_names, ctx):
+    int64_info = np.iinfo(np.int64)
+    slices = func.slices if isinstance(func.slices, tuple) else (func.slices,)
+
+    if len(slices) == 1 and isinstance(slices[0], (np.ndarray, list)):
+        indices = np.asarray(slices[0])
+        if indices.dtype.kind not in "iu":
+            raise ONNXExportError("GetItem with non-integer array indices is not supported.")
+        indices_name = ctx.constant(indices.astype(np.int64), "gather_indices")
+        ctx.add_node("Gather", [in_names[0], indices_name], out_names, axis=0)
+        return
+
+    starts, ends, axes, steps, squeeze_axes = [], [], [], [], []
+    for axis, item in enumerate(slices):
+        if isinstance(item, (int, np.integer)):
+            index = int(item)
+            starts.append(index)
+            ends.append(index + 1 if index != -1 else int64_info.max)
+            axes.append(axis)
+            steps.append(1)
+            squeeze_axes.append(axis)
+        elif isinstance(item, slice):
+            step = item.step if item.step is not None else 1
+            if step > 0:
+                start = item.start if item.start is not None else 0
+                end = item.stop if item.stop is not None else int64_info.max
+            else:
+                start = item.start if item.start is not None else -1
+                end = item.stop if item.stop is not None else int64_info.min
+            starts.append(int(start))
+            ends.append(int(end))
+            axes.append(axis)
+            steps.append(int(step))
+        else:
+            raise ONNXExportError(
+                "GetItem with `{}` index is not supported.".format(type(item).__name__))
+
+    if not axes:
+        ctx.add_node("Identity", in_names, out_names)
+        return
+
+    slice_inputs = [
+        in_names[0],
+        ctx.constant(np.asarray(starts, dtype=np.int64), "slice_starts"),
+        ctx.constant(np.asarray(ends, dtype=np.int64), "slice_ends"),
+        ctx.constant(np.asarray(axes, dtype=np.int64), "slice_axes"),
+        ctx.constant(np.asarray(steps, dtype=np.int64), "slice_steps"),
+    ]
+
+    if squeeze_axes:
+        sliced = ctx.intermediate("sliced")
+        ctx.add_node("Slice", slice_inputs, [sliced])
+        squeeze_name = ctx.constant(np.asarray(squeeze_axes, dtype=np.int64), "squeeze_axes")
+        ctx.add_node("Squeeze", [sliced, squeeze_name], out_names)
+    else:
+        ctx.add_node("Slice", slice_inputs, out_names)
+
+
+# ===========================================================================
+# connection
+# ===========================================================================
+@register("Linear")
+def _convert_linear(func, in_names, out_names, ctx):
+    has_bias = bool(in_names[2])
+    if func.inputs[0].ndim == 2:
+        inputs = in_names[:3] if has_bias else in_names[:2]
+        ctx.add_node("Gemm", inputs, out_names)
+    elif has_bias:
+        product = ctx.intermediate("linear_matmul")
+        ctx.add_node("MatMul", in_names[:2], [product])
+        ctx.add_node("Add", [product, in_names[2]], out_names)
+    else:
+        ctx.add_node("MatMul", in_names[:2], out_names)
+
+
+@register("Convolution2D")
+def _convert_convolution_2d(func, in_names, out_names, ctx):
+    pad_height, pad_width = func.pad
+    inputs = in_names[:3] if in_names[2] else in_names[:2]
+    ctx.add_node("Conv", inputs, out_names,
+                 strides=list(func.stride),
+                 pads=[pad_height, pad_width, pad_height, pad_width])
+
+
+@register("Deconvolution2D")
+def _convert_deconvolution_2d(func, in_names, out_names, ctx):
+    pad_height, pad_width = func.pad
+    if func.out_size is not None:
+        x_shape = func.inputs[0].shape
+        w_shape = func.inputs[1].shape
+        expected = tuple(
+            utils.get_deconvolution_outsize(size, kernel, stride, pad)
+            for size, kernel, stride, pad in zip(
+                x_shape[2:], w_shape[2:], func.stride, func.pad))
+        if tuple(utils.pair(func.out_size)) != expected:
+            raise ONNXExportError(
+                "Deconvolution2D with a custom out_size is not supported in the ONNX export.")
+
+    inputs = in_names[:3] if in_names[2] else in_names[:2]
+    ctx.add_node("ConvTranspose", inputs, out_names,
+                 strides=list(func.stride),
+                 pads=[pad_height, pad_width, pad_height, pad_width])
+
+
+# ===========================================================================
+# pooling
+# ===========================================================================
+@register("MaxPooling2D")
+def _convert_max_pooling_2d(func, in_names, out_names, ctx):
+    kernel = list(utils.pair(func.kernel_size))
+    strides = list(utils.pair(func.stride))
+    pad_height, pad_width = utils.pair(func.pad)
+
+    ctx.add_node("MaxPool", in_names, out_names, kernel_shape=kernel, strides=strides,
+                 pads=[pad_height, pad_width, pad_height, pad_width])
+
+
+# ===========================================================================
+# normalization
+# ===========================================================================
+@register("BatchNormalization")
+def _convert_batch_normalization(func, in_names, out_names, ctx):
+    mean_name = ctx.constant(func.avg_mean, "batch_norm_mean")
+    var_name = ctx.constant(func.avg_var, "batch_norm_var")
+    ctx.add_node("BatchNormalization",
+                 [in_names[0], in_names[1], in_names[2], mean_name, var_name],
+                 out_names, epsilon=float(func.eps))
+
+
+@register("LayerNormalization")
+def _convert_layer_normalization(func, in_names, out_names, ctx):
+    x_node = func.inputs[0]
+    if x_node.ndim == 2:
+        ctx.add_node("LayerNormalization", in_names, out_names,
+                     axis=-1, epsilon=float(func.eps))
+        return
+
+    # Marquetry normalizes 4D inputs over all the non-batch axes at once,
+    # so flatten, normalize the last axis, then restore the original shape.
+    flat_shape = ctx.constant(np.asarray([0, -1], dtype=np.int64), "layer_norm_flat_shape")
+    flattened = ctx.intermediate("layer_norm_flat")
+    ctx.add_node("Reshape", [in_names[0], flat_shape], [flattened])
+
+    normalized = ctx.intermediate("layer_norm_out")
+    ctx.add_node("LayerNormalization", [flattened, in_names[1], in_names[2]], [normalized],
+                 axis=-1, epsilon=float(func.eps))
+
+    original_shape = [0] + [int(dim) for dim in x_node.shape[1:]]
+    shape_name = ctx.constant(np.asarray(original_shape, dtype=np.int64), "layer_norm_shape")
+    ctx.add_node("Reshape", [normalized, shape_name], out_names)
+
+
+@register("L2Normalization")
+def _convert_l2_normalization(func, in_names, out_names, ctx):
+    dtype = _input_dtype(func)
+    axis = func.axis
+    axes = (axis,) if isinstance(axis, int) else tuple(axis)
+
+    squared = ctx.intermediate("l2_norm_squared")
+    ctx.add_node("Mul", [in_names[0], in_names[0]], [squared])
+
+    axes_name = ctx.constant(np.asarray(axes, dtype=np.int64), "l2_norm_axes")
+    summed = ctx.intermediate("l2_norm_sum")
+    ctx.add_node("ReduceSum", [squared, axes_name], [summed], keepdims=1)
+
+    root = ctx.intermediate("l2_norm_root")
+    ctx.add_node("Sqrt", [summed], [root])
+
+    eps_name = ctx.constant(np.asarray(func.eps, dtype=dtype), "l2_norm_eps")
+    denominator = ctx.intermediate("l2_norm_denominator")
+    ctx.add_node("Add", [root, eps_name], [denominator])
+
+    ctx.add_node("Div", [in_names[0], denominator], out_names)
+
+
+# ===========================================================================
+# activations
+# ===========================================================================
+for _marquetry_name, _onnx_op in [
+    ("ReLU", "Relu"), ("Sigmoid", "Sigmoid"), ("Tanh", "Tanh"),
+    ("Mish", "Mish"), ("Identity", "Identity"),
+]:
+    _register_direct(_marquetry_name, _onnx_op)
+
+
+@register("LeakyReLU")
+def _convert_leaky_relu(func, in_names, out_names, ctx):
+    ctx.add_node("LeakyRelu", in_names, out_names, alpha=float(func.slope))
+
+
+@register("Softmax")
+def _convert_softmax(func, in_names, out_names, ctx):
+    ctx.add_node("Softmax", in_names, out_names, axis=int(func.axis))
+
+
+@register("LogSoftmax")
+def _convert_log_softmax(func, in_names, out_names, ctx):
+    ctx.add_node("LogSoftmax", in_names, out_names, axis=int(func.axis))
+
+
+@register("Softplus")
+def _convert_softplus(func, in_names, out_names, ctx):
+    if func.beta == 1:
+        ctx.add_node("Softplus", in_names, out_names)
+        return
+
+    beta_name = ctx.constant(np.asarray(func.beta, dtype=_input_dtype(func)), "softplus_beta")
+    scaled = ctx.intermediate("softplus_scaled")
+    ctx.add_node("Mul", [in_names[0], beta_name], [scaled])
+    activated = ctx.intermediate("softplus_activated")
+    ctx.add_node("Softplus", [scaled], [activated])
+    ctx.add_node("Div", [activated, beta_name], out_names)
+
+
+@register("GELU")
+def _convert_gelu(func, in_names, out_names, ctx):
+    if func.approximate in ("none", "tanh"):
+        ctx.add_node("Gelu", in_names, out_names, approximate=func.approximate)
+        return
+
+    # The sigmoid approximation has no ONNX counterpart: x * sigmoid(1.702 * x)
+    scale_name = ctx.constant(np.asarray(1.702, dtype=_input_dtype(func)), "gelu_scale")
+    scaled = ctx.intermediate("gelu_scaled")
+    ctx.add_node("Mul", [in_names[0], scale_name], [scaled])
+    gate = ctx.intermediate("gelu_gate")
+    ctx.add_node("Sigmoid", [scaled], [gate])
+    ctx.add_node("Mul", [in_names[0], gate], out_names)
+
+
+@register("GLU")
+def _convert_glu(func, in_names, out_names, ctx):
+    first_half = ctx.intermediate("glu_value")
+    second_half = ctx.intermediate("glu_gate_source")
+    ctx.add_node("Split", [in_names[0]], [first_half, second_half],
+                 axis=int(func.axis), num_outputs=2)
+    gate = ctx.intermediate("glu_gate")
+    ctx.add_node("Sigmoid", [second_half], [gate])
+    ctx.add_node("Mul", [first_half, gate], out_names)
+
+
+@register("PReLU")
+def _convert_prelu(func, in_names, out_names, ctx):
+    # ONNX PRelu broadcasts the slope unidirectionally, so reshape the per-channel
+    # alpha to the channel-aligned shape recorded in the forward pass (e.g. (1, C, 1, 1)).
+    slope_source = _cast_like_first_input(func, in_names[1], "prelu_slope_cast", ctx)
+    slope_shape = ctx.constant(
+        np.asarray(tuple(func.ex_alpha_shape), dtype=np.int64), "prelu_slope_shape")
+    slope = ctx.intermediate("prelu_slope")
+    ctx.add_node("Reshape", [slope_source, slope_shape], [slope])
+    ctx.add_node("PRelu", [in_names[0], slope], out_names)
+
+
+def _emit_swish(in_name, out_names, beta_name, ctx):
+    if beta_name is None:
+        scaled = in_name
+    else:
+        scaled = ctx.intermediate("swish_scaled")
+        ctx.add_node("Mul", [in_name, beta_name], [scaled])
+    gate = ctx.intermediate("swish_gate")
+    ctx.add_node("Sigmoid", [scaled], [gate])
+    ctx.add_node("Mul", [in_name, gate], out_names)
+
+
+@register("Swish")
+def _convert_swish(func, in_names, out_names, ctx):
+    if func.beta == 1:
+        beta_name = None
+    else:
+        beta_name = ctx.constant(np.asarray(func.beta, dtype=_input_dtype(func)), "swish_beta")
+    _emit_swish(in_names[0], out_names, beta_name, ctx)
+
+
+@register("DynamicSwish")
+def _convert_dynamic_swish(func, in_names, out_names, ctx):
+    beta_name = _cast_like_first_input(func, in_names[1], "swish_beta_cast", ctx)
+    _emit_swish(in_names[0], out_names, beta_name, ctx)
+
+
+# ===========================================================================
+# regularization
+# ===========================================================================
+@register("Dropout")
+def _convert_dropout(func, in_names, out_names, ctx):
+    # Inference graphs don't need dropout; it traces as the identity in test mode.
+    ctx.add_node("Identity", in_names, out_names)

--- a/marquetry/onnx_export/exporter.py
+++ b/marquetry/onnx_export/exporter.py
@@ -1,0 +1,314 @@
+import numpy as np
+
+import onnx
+from onnx import helper
+from onnx import numpy_helper
+
+import marquetry
+from marquetry import cuda_backend
+from marquetry.onnx_export import converters
+from marquetry.onnx_export.converters import ONNXExportError
+
+
+DEFAULT_OPSET_VERSION = 21
+MINIMUM_OPSET_VERSION = 18
+TARGET_IR_VERSION = 10
+BATCH_DIM_PARAM = "batch_size"
+
+
+class ExportContext(object):
+    """Mutable state shared with the op converters while a graph is being built.
+
+        Collects the ONNX nodes and initializers, and owns the SSA name table
+        which maps :class:`marquetry.container.ContainerNode` objects to unique
+        tensor names.
+    """
+
+    def __init__(self, opset_version, dynamic_batch, batch_size):
+        self.opset_version = opset_version
+        self.dynamic_batch = dynamic_batch
+        self.batch_size = batch_size
+
+        self.nodes = []
+        self.initializers = []
+
+        self._names = {}
+        self._taken = set()
+        self._counts = {}
+        # id() keys are only stable while the objects live, so hold strong refs.
+        self._keepalive = []
+
+    def fresh_name(self, hint):
+        hint = hint or "tensor"
+        count = self._counts.get(hint, 0)
+        while True:
+            name = hint if count == 0 else "{}_{}".format(hint, count)
+            count += 1
+            if name not in self._taken:
+                break
+        self._counts[hint] = count
+        self._taken.add(name)
+
+        return name
+
+    def has_name(self, container_node):
+        return id(container_node) in self._names
+
+    def name_of(self, container_node):
+        return self._names[id(container_node)]
+
+    def assign_name(self, container_node, hint):
+        name = self.fresh_name(hint)
+        self._names[id(container_node)] = name
+        self._keepalive.append(container_node)
+
+        return name
+
+    def set_name(self, container_node, name):
+        if name in self._taken:
+            raise ONNXExportError("tensor name `{}` is specified twice.".format(name))
+        self._taken.add(name)
+        self._names[id(container_node)] = name
+        self._keepalive.append(container_node)
+
+    def intermediate(self, hint):
+        return self.fresh_name(hint)
+
+    def add_initializer(self, name, array):
+        array = np.ascontiguousarray(cuda_backend.as_numpy(array))
+        self.initializers.append(numpy_helper.from_array(array, name))
+
+    def constant(self, array, hint, dtype=None):
+        array = np.asarray(cuda_backend.as_numpy(array))
+        if dtype is not None:
+            array = array.astype(dtype, copy=False)
+        name = self.fresh_name(hint)
+        self.add_initializer(name, array)
+
+        return name
+
+    def add_node(self, op_type, inputs, outputs, **attributes):
+        node = helper.make_node(op_type, list(inputs), list(outputs),
+                                name=self.fresh_name(op_type), **attributes)
+        self.nodes.append(node)
+
+
+def export_onnx(model, inputs, file_path=None, *, opset_version=DEFAULT_OPSET_VERSION,
+                dynamic_batch=True, input_names=None, output_names=None, check=True):
+    """Export a model to an ONNX inference graph.
+
+        Runs one forward pass with the sample inputs in test mode, walks the recorded
+        computation graph, and converts every traced function to ONNX operators.
+        The produced model is pinned to ``opset_version`` and IR version 10 so that
+        it stays loadable by widely deployed ONNX Runtime versions.
+
+        Args:
+            model (marquetry.Model or marquetry.Layer): The model to export.
+            inputs: A sample input array (or :class:`marquetry.Container`), or a
+                tuple/list of them for multi-input models. The traced graph is
+                specialized to these shapes (except the batch axis).
+            file_path (str or None): If given, the model is also serialized to this path.
+            opset_version (int): Target opset of the default ONNX domain. Defaults to 21.
+            dynamic_batch (bool): If True, the leading axis of every graph input/output
+                is exported as a symbolic ``batch_size`` dimension.
+            input_names (list of str or None): Names for the graph inputs.
+            output_names (list of str or None): Names for the graph outputs.
+            check (bool): If True, run ``onnx.checker.check_model`` on the result.
+
+        Returns:
+            onnx.ModelProto: The exported model.
+    """
+
+    if opset_version < MINIMUM_OPSET_VERSION:
+        raise ValueError(
+            "opset_version should be {} or later, but got {}."
+            .format(MINIMUM_OPSET_VERSION, opset_version))
+    if opset_version > onnx.defs.onnx_opset_version():
+        raise ValueError(
+            "opset_version {} isn't supported by the installed onnx package (max: {})."
+            .format(opset_version, onnx.defs.onnx_opset_version()))
+
+    input_list = list(inputs) if isinstance(inputs, (tuple, list)) else [inputs]
+    if not input_list:
+        raise ValueError("at least one sample input is needed to trace the model.")
+
+    input_containers = []
+    for sample in input_list:
+        container = marquetry.as_container(sample)
+        if container.data is None:
+            raise ValueError("sample inputs should hold data, but got an empty container.")
+        input_containers.append(container)
+
+    with marquetry.using_config("train", False):
+        with marquetry.using_config("enable_backprop", True):
+            with marquetry.using_config("retain_graph_inputs", True):
+                outputs = model(*input_containers)
+    outputs = tuple(outputs) if isinstance(outputs, (tuple, list)) else (outputs,)
+
+    first_input = input_containers[0]
+    batch_size = first_input.shape[0] if first_input.ndim >= 1 else None
+    context = ExportContext(opset_version, dynamic_batch, batch_size)
+
+    input_names = _default_io_names(input_names, len(input_containers), "input")
+    output_names = _default_io_names(output_names, len(outputs), "output")
+
+    for container, name in zip(input_containers, input_names):
+        context.set_name(container.node, name)
+
+    # An output that is an input itself (or appears twice) needs an Identity bridge
+    # because its tensor name is already taken.
+    output_aliases = []
+    for container, name in zip(outputs, output_names):
+        if context.has_name(container.node):
+            output_aliases.append((context.name_of(container.node), name))
+        else:
+            context.set_name(container.node, name)
+
+    parameter_lookup = _build_parameter_lookup(model)
+
+    functions = _topological_functions(outputs)
+    if not functions and not output_aliases:
+        raise ONNXExportError(
+            "no computation graph is recorded from the model outputs. "
+            "The export needs to run under back-propagation enabled mode.")
+
+    for function in functions:
+        in_names = [_resolve_input_name(node, context, parameter_lookup)
+                    for node in function.inputs]
+
+        out_names = []
+        for reference in function.outputs:
+            out_node = reference()
+            if out_node is None:
+                out_names.append(context.fresh_name("unused"))
+            elif context.has_name(out_node):
+                out_names.append(context.name_of(out_node))
+            else:
+                out_names.append(context.assign_name(out_node, function.name.lower() + "_out"))
+
+        converter = converters.lookup(function)
+        if converter is None:
+            raise ONNXExportError(
+                "`{}` can't be converted to ONNX operators. "
+                "Please replace it or export without this computation."
+                .format(function.name))
+
+        converter(function, in_names, out_names, context)
+
+    for source_name, alias_name in output_aliases:
+        context._taken.add(alias_name)
+        context.add_node("Identity", [source_name], [alias_name])
+
+    graph_inputs = [_tensor_value_info(name, container.data, context)
+                    for name, container in zip(input_names, input_containers)]
+    graph_outputs = [_tensor_value_info(name, container.data, context)
+                     for name, container in zip(output_names, outputs)]
+
+    graph = helper.make_graph(context.nodes, type(model).__name__,
+                              graph_inputs, graph_outputs,
+                              initializer=context.initializers)
+
+    model_proto = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", opset_version)],
+        producer_name="marquetry")
+    # helper.make_model stamps the installed package's latest IR version, which old
+    # runtimes reject, so pin it down explicitly.
+    model_proto.ir_version = TARGET_IR_VERSION
+
+    if check:
+        onnx.checker.check_model(model_proto)
+
+    if file_path is not None:
+        onnx.save(model_proto, file_path)
+
+    return model_proto
+
+
+def _default_io_names(names, count, prefix):
+    if names is None:
+        if count == 1:
+            return [prefix]
+        return ["{}_{}".format(prefix, index) for index in range(count)]
+
+    names = list(names)
+    if len(names) != count:
+        raise ValueError(
+            "{} names are needed for {} tensors, but got {}.".format(prefix, count, len(names)))
+
+    return names
+
+
+def _build_parameter_lookup(model):
+    lookup = {}
+    if not hasattr(model, "_flatten_params"):
+        return lookup
+
+    params_dict = {}
+    model._flatten_params(params_dict)
+    for key, param in params_dict.items():
+        if param is None or param.data is None:
+            continue
+        lookup[id(param.node)] = (key, param.data)
+
+    return lookup
+
+
+def _topological_functions(outputs):
+    functions = []
+    seen = set()
+
+    stack = [output.creator for output in outputs if output.creator is not None]
+    while stack:
+        function = stack.pop()
+        if function in seen:
+            continue
+        seen.add(function)
+        functions.append(function)
+
+        for in_node in function.inputs:
+            if in_node.creator is not None:
+                stack.append(in_node.creator)
+
+    # The generation number strictly increases along every edge,
+    # so sorting by it yields a valid topological (executable) order.
+    functions.sort(key=lambda recorded: recorded.generation)
+
+    return functions
+
+
+def _resolve_input_name(container_node, context, parameter_lookup):
+    if context.has_name(container_node):
+        return context.name_of(container_node)
+
+    if container_node.creator is not None:
+        raise ONNXExportError(
+            "internal error: encountered an input produced by an unconverted function.")
+
+    parameter_entry = parameter_lookup.get(id(container_node))
+    if parameter_entry is not None:
+        key, data = parameter_entry
+        name = context.assign_name(container_node, key)
+        context.add_initializer(name, data)
+        return name
+
+    if container_node.data is None:
+        # Absent optional input such as a omitted bias.
+        return ""
+
+    name = context.assign_name(container_node, "const")
+    context.add_initializer(name, container_node.data)
+
+    return name
+
+
+def _tensor_value_info(name, array, context):
+    array = cuda_backend.as_numpy(array)
+    element_type = helper.np_dtype_to_tensor_dtype(np.dtype(array.dtype))
+
+    shape = list(array.shape)
+    if (context.dynamic_batch and shape
+            and context.batch_size is not None and shape[0] == context.batch_size):
+        shape[0] = BATCH_DIM_PARAM
+
+    return helper.make_tensor_value_info(name, element_type, shape)

--- a/marquetry/utils/array/im2col_array.py
+++ b/marquetry/utils/array/im2col_array.py
@@ -2,7 +2,7 @@ import marquetry
 from marquetry import cuda_backend
 
 
-def im2col_array(img, kernel_size, stride, pad, to_matrix=True):
+def im2col_array(img, kernel_size, stride, pad, to_matrix=True, pad_value=0):
     """The util of im2col main process"""
 
     batch_size, channels, height, weight = img.shape
@@ -19,7 +19,7 @@ def im2col_array(img, kernel_size, stride, pad, to_matrix=True):
     img = xp.pad(img, (
         (0, 0), (0, 0),
         (padding_height, padding_height + stride_height - 1),
-        (padding_width, padding_width + stride_width - 1)), mode="constant", constant_values=(0,))
+        (padding_width, padding_width + stride_width - 1)), mode="constant", constant_values=(pad_value,))
 
     # output array which has 6-dims to handle the local area extraction.
     col = xp.ndarray((batch_size, channels, kernel_height, kernel_width, out_height, out_width), dtype=img.dtype)

--- a/tests/test_onnx_e2e.py
+++ b/tests/test_onnx_e2e.py
@@ -25,7 +25,12 @@ class FuncModel(Model):
 def run_onnx(proto, inputs):
     session = onnxruntime.InferenceSession(
         proto.SerializeToString(), providers=["CPUExecutionProvider"])
-    feeds = {meta.name: np.asarray(data) for meta, data in zip(session.get_inputs(), inputs)}
+    input_metas = session.get_inputs()
+    if len(input_metas) != len(inputs):
+        raise AssertionError(
+            "the exported model expects {} inputs, but {} were provided."
+            .format(len(input_metas), len(inputs)))
+    feeds = {meta.name: np.asarray(data) for meta, data in zip(input_metas, inputs)}
 
     return session.run(None, feeds)
 

--- a/tests/test_onnx_e2e.py
+++ b/tests/test_onnx_e2e.py
@@ -186,6 +186,12 @@ class TestActivations(unittest.TestCase):
     def test_gelu_sigmoid(self):
         self._check(lambda x: funcs.gelu(x, approximate="sigmoid"))
 
+    def test_gelu_exact_decomposed_for_opset18(self):
+        self._check(lambda x: funcs.gelu(x, approximate="none"), opset_version=18)
+
+    def test_gelu_tanh_decomposed_for_opset18(self):
+        self._check(lambda x: funcs.gelu(x, approximate="tanh"), opset_version=18)
+
     def test_glu(self):
         self._check(funcs.glu)
 

--- a/tests/test_onnx_e2e.py
+++ b/tests/test_onnx_e2e.py
@@ -1,0 +1,393 @@
+import unittest
+
+import numpy as np
+import onnxruntime
+
+import marquetry
+import marquetry.functions as funcs
+import marquetry.layers as layers
+from marquetry import Model
+from marquetry.models import CNN, MLP, Sequential
+from marquetry.onnx_export import export_onnx
+
+
+class FuncModel(Model):
+    """Wrap a plain callable so function-level graphs can be exported and compared."""
+
+    def __init__(self, fn):
+        super().__init__()
+        self._fn = fn
+
+    def forward(self, *inputs):
+        return self._fn(*inputs)
+
+
+def run_onnx(proto, inputs):
+    session = onnxruntime.InferenceSession(
+        proto.SerializeToString(), providers=["CPUExecutionProvider"])
+    feeds = {meta.name: np.asarray(data) for meta, data in zip(session.get_inputs(), inputs)}
+
+    return session.run(None, feeds)
+
+
+def assert_equivalent(testcase, model, inputs, rtol=1e-5, atol=1e-6, **export_kwargs):
+    """Export the model and compare onnxruntime outputs with marquetry's test-mode forward."""
+    if not isinstance(inputs, (tuple, list)):
+        inputs = [inputs]
+
+    with marquetry.test_mode():
+        expected = model(*[marquetry.as_container(np.copy(x)) for x in inputs])
+    expected = expected if isinstance(expected, tuple) else (expected,)
+
+    proto = export_onnx(model, [np.copy(x) for x in inputs], **export_kwargs)
+    actual = run_onnx(proto, inputs)
+
+    testcase.assertEqual(len(actual), len(expected))
+    for got, exp in zip(actual, expected):
+        np.testing.assert_allclose(got, exp.data, rtol=rtol, atol=atol)
+
+    return proto
+
+
+def random_array(*shape):
+    return np.random.randn(*shape).astype(np.float32)
+
+
+class TestLinear(unittest.TestCase):
+
+    def test_linear_with_bias(self):
+        assert_equivalent(self, Sequential(layers.Linear(7)), random_array(4, 3))
+
+    def test_linear_without_bias(self):
+        assert_equivalent(self, Sequential(layers.Linear(7, nobias=True)), random_array(4, 3))
+
+    def test_linear_3d_input(self):
+        assert_equivalent(self, Sequential(layers.Linear(6)), random_array(2, 5, 3))
+
+    def test_linear_3d_input_without_bias(self):
+        assert_equivalent(
+            self, Sequential(layers.Linear(6, nobias=True)), random_array(2, 5, 3))
+
+
+class TestConvolutionAndPooling(unittest.TestCase):
+
+    def test_convolution(self):
+        assert_equivalent(
+            self, Sequential(layers.Convolution2D(8, (3, 3))), random_array(2, 3, 8, 8),
+            rtol=1e-4, atol=1e-5)
+
+    def test_convolution_stride_pad(self):
+        assert_equivalent(
+            self, Sequential(layers.Convolution2D(4, (3, 3), stride=2, pad=1)),
+            random_array(2, 3, 9, 9), rtol=1e-4, atol=1e-5)
+
+    def test_convolution_without_bias(self):
+        assert_equivalent(
+            self, Sequential(layers.Convolution2D(4, (3, 3), nobias=True)),
+            random_array(2, 3, 8, 8), rtol=1e-4, atol=1e-5)
+
+    def test_deconvolution(self):
+        assert_equivalent(
+            self, Sequential(layers.Deconvolution2D(4, (3, 3), stride=2, pad=1)),
+            random_array(2, 3, 5, 5), rtol=1e-4, atol=1e-5)
+
+    def test_max_pooling(self):
+        assert_equivalent(
+            self, FuncModel(lambda x: funcs.max_pooling_2d(x, (2, 2))),
+            random_array(2, 3, 8, 8))
+
+    def test_max_pooling_with_pad(self):
+        # Negative inputs make the zero-padding visible if it is mistranslated.
+        x = random_array(2, 3, 7, 7) - 5.0
+        assert_equivalent(
+            self, FuncModel(lambda x: funcs.max_pooling_2d(x, (3, 3), stride=2, pad=1)), x)
+
+
+class TestNormalization(unittest.TestCase):
+
+    def _trained_batch_norm(self, sample_shape):
+        model = Sequential(layers.BatchNormalization())
+        for _ in range(3):
+            model(random_array(*sample_shape) * 2.0 + 1.0)
+
+        return model
+
+    def test_batch_normalization_2d(self):
+        model = self._trained_batch_norm((8, 5))
+        assert_equivalent(self, model, random_array(4, 5))
+
+    def test_batch_normalization_4d(self):
+        model = self._trained_batch_norm((4, 3, 6, 6))
+        assert_equivalent(self, model, random_array(2, 3, 6, 6))
+
+    def test_layer_normalization_2d(self):
+        assert_equivalent(
+            self, Sequential(layers.LayerNormalization()), random_array(4, 6),
+            rtol=1e-4, atol=1e-5)
+
+    def test_layer_normalization_4d(self):
+        assert_equivalent(
+            self, Sequential(layers.LayerNormalization()), random_array(2, 3, 4, 4),
+            rtol=1e-4, atol=1e-5)
+
+    def test_l2_normalization(self):
+        assert_equivalent(
+            self, FuncModel(lambda x: funcs.l2_normalization(x, axis=1)), random_array(4, 6))
+
+
+class TestActivations(unittest.TestCase):
+
+    def _check(self, fn, x=None, **kwargs):
+        if x is None:
+            x = random_array(4, 6)
+        assert_equivalent(self, FuncModel(fn), x, **kwargs)
+
+    def test_relu(self):
+        self._check(funcs.relu)
+
+    def test_leaky_relu(self):
+        self._check(lambda x: funcs.leaky_relu(x, slope=0.1))
+
+    def test_sigmoid(self):
+        self._check(funcs.sigmoid)
+
+    def test_tanh(self):
+        self._check(funcs.tanh)
+
+    def test_softmax_axis1(self):
+        self._check(lambda x: funcs.softmax(x, axis=1))
+
+    def test_softmax_last_axis(self):
+        self._check(lambda x: funcs.softmax(x, axis=2), x=random_array(2, 3, 5))
+
+    def test_log_softmax(self):
+        self._check(lambda x: funcs.log_softmax(x, axis=1))
+
+    def test_softplus(self):
+        self._check(funcs.softplus)
+
+    def test_softplus_beta(self):
+        self._check(lambda x: funcs.softplus(x, beta=2))
+
+    def test_mish(self):
+        self._check(funcs.mish)
+
+    def test_gelu_exact(self):
+        self._check(lambda x: funcs.gelu(x, approximate="none"))
+
+    def test_gelu_tanh(self):
+        self._check(lambda x: funcs.gelu(x, approximate="tanh"))
+
+    def test_gelu_sigmoid(self):
+        self._check(lambda x: funcs.gelu(x, approximate="sigmoid"))
+
+    def test_glu(self):
+        self._check(funcs.glu)
+
+    def test_swish(self):
+        self._check(funcs.swish)
+
+    def test_swish_beta(self):
+        self._check(lambda x: funcs.swish(x, beta=2.0))
+
+    def test_identity(self):
+        self._check(funcs.identity)
+
+    def test_prelu_layer_2d(self):
+        model = Sequential(layers.PReLU(num_parameter=6, init=0.3))
+        assert_equivalent(self, model, random_array(4, 6))
+
+    def test_prelu_layer_4d(self):
+        model = Sequential(layers.PReLU(num_parameter=3, init=0.3))
+        assert_equivalent(self, model, random_array(2, 3, 5, 5))
+
+    def test_dynamic_swish_layer(self):
+        assert_equivalent(self, Sequential(layers.DynamicSwish()), random_array(4, 6))
+
+    def test_dropout_is_inference_identity(self):
+        self._check(lambda x: funcs.dropout(x, 0.5))
+
+
+class TestMath(unittest.TestCase):
+
+    def _check(self, fn, x=None, **kwargs):
+        if x is None:
+            x = random_array(4, 5)
+        assert_equivalent(self, FuncModel(fn), x, **kwargs)
+
+    def test_add_tensors(self):
+        assert_equivalent(
+            self, FuncModel(lambda a, b: a + b), [random_array(4, 5), random_array(4, 5)])
+
+    def test_add_broadcast(self):
+        assert_equivalent(
+            self, FuncModel(lambda a, b: a + b), [random_array(4, 5), random_array(5)])
+
+    def test_add_scalar(self):
+        self._check(lambda x: x + 2.0)
+
+    def test_sub(self):
+        assert_equivalent(
+            self, FuncModel(lambda a, b: a - b), [random_array(4, 5), random_array(4, 5)])
+
+    def test_mul(self):
+        assert_equivalent(
+            self, FuncModel(lambda a, b: a * b), [random_array(4, 5), random_array(4, 5)])
+
+    def test_div(self):
+        denominator = np.abs(random_array(4, 5)) + 1.0
+        assert_equivalent(
+            self, FuncModel(lambda a, b: a / b), [random_array(4, 5), denominator])
+
+    def test_neg(self):
+        self._check(lambda x: -x)
+
+    def test_pow(self):
+        self._check(lambda x: x ** 3)
+
+    def test_absolute(self):
+        self._check(funcs.absolute)
+
+    def test_exp(self):
+        self._check(funcs.exp)
+
+    def test_log(self):
+        self._check(funcs.log, x=np.abs(random_array(4, 5)) + 0.5)
+
+    def test_log2(self):
+        self._check(funcs.log2, x=np.abs(random_array(4, 5)) + 0.5)
+
+    def test_log10(self):
+        self._check(funcs.log10, x=np.abs(random_array(4, 5)) + 0.5)
+
+    def test_sqrt(self):
+        self._check(funcs.sqrt, x=np.abs(random_array(4, 5)) + 0.5)
+
+    def test_square(self):
+        self._check(funcs.square)
+
+    def test_clip(self):
+        self._check(lambda x: funcs.clip(x, -0.5, 0.5))
+
+    def test_matmul(self):
+        assert_equivalent(
+            self, FuncModel(funcs.matmul), [random_array(4, 5), random_array(5, 3)])
+
+    def test_chained_expression(self):
+        self._check(lambda x: (x * 2.0 + 1.0) / (funcs.exp(-x) + 2.0))
+
+
+class TestReductions(unittest.TestCase):
+
+    def _check(self, fn, x=None, **kwargs):
+        if x is None:
+            x = random_array(3, 4, 5)
+        assert_equivalent(self, FuncModel(fn), x, **kwargs)
+
+    def test_sum_all(self):
+        self._check(lambda x: funcs.sum(x))
+
+    def test_sum_axis_keepdims(self):
+        self._check(lambda x: funcs.sum(x, axis=1, keepdims=True))
+
+    def test_mean(self):
+        self._check(lambda x: funcs.mean(x, axis=2))
+
+    def test_max(self):
+        self._check(lambda x: funcs.max(x, axis=1))
+
+    def test_min(self):
+        self._check(lambda x: funcs.min(x, axis=(0, 2), keepdims=True))
+
+
+class TestArrayOperations(unittest.TestCase):
+
+    def _check(self, fn, x=None, **kwargs):
+        if x is None:
+            x = random_array(2, 3, 4)
+        assert_equivalent(self, FuncModel(fn), x, **kwargs)
+
+    def test_reshape(self):
+        self._check(lambda x: funcs.reshape(x, (2, 12)))
+
+    def test_flatten(self):
+        self._check(funcs.flatten)
+
+    def test_transpose_default(self):
+        self._check(lambda x: funcs.transpose(x))
+
+    def test_transpose_perm(self):
+        self._check(lambda x: funcs.transpose(x, (1, 0, 2)))
+
+    def test_concat(self):
+        assert_equivalent(
+            self, FuncModel(lambda a, b: funcs.concat((a, b), axis=1)),
+            [random_array(2, 3), random_array(2, 4)])
+
+    def test_squeeze(self):
+        self._check(lambda x: funcs.squeeze(x, axis=1), x=random_array(3, 1, 4))
+
+    def test_unsqueeze(self):
+        self._check(lambda x: funcs.unsqueeze(x, 1), x=random_array(3, 4))
+
+    def test_broadcast_to(self):
+        self._check(lambda x: funcs.broadcast_to(x, (2, 3, 4)), x=random_array(3, 4))
+
+    def test_split_sections(self):
+        x = random_array(4, 6)
+        model = FuncModel(lambda x: tuple(funcs.split(x, 2, axis=1)))
+        proto = assert_equivalent(self, model, x)
+        self.assertEqual(len(proto.graph.output), 2)
+
+    def test_get_item_slices(self):
+        self._check(lambda x: x[:, 1:3])
+
+    def test_get_item_integer(self):
+        self._check(lambda x: x[1])
+
+    def test_get_item_step(self):
+        self._check(lambda x: x[::2])
+
+
+class TestModels(unittest.TestCase):
+
+    def test_mlp_with_dropout(self):
+        model = MLP([16, 8], activation=funcs.relu, is_dropout=True)
+        assert_equivalent(self, model, random_array(4, 12))
+
+    def test_mlp_sigmoid_without_dropout(self):
+        model = MLP([16, 8], activation=funcs.sigmoid, is_dropout=False)
+        assert_equivalent(self, model, random_array(4, 12))
+
+    def test_cnn(self):
+        model = CNN(10)
+        assert_equivalent(self, model, random_array(2, 1, 12, 12), rtol=1e-4, atol=1e-5)
+
+    def test_sequential_mixed(self):
+        model = Sequential(
+            layers.Convolution2D(4, (3, 3), pad=1),
+            layers.BatchNormalization(),
+            funcs.relu,
+            funcs.flatten,
+            layers.Linear(5),
+        )
+        model(random_array(4, 3, 6, 6))  # one train-mode pass to give BN real statistics
+        assert_equivalent(self, model, random_array(2, 3, 6, 6), rtol=1e-4, atol=1e-5)
+
+    def test_dynamic_batch_runs_other_batch_sizes(self):
+        model = CNN(7)
+        traced = random_array(2, 1, 12, 12)
+        proto = assert_equivalent(self, model, traced, rtol=1e-4, atol=1e-5)
+
+        session = onnxruntime.InferenceSession(
+            proto.SerializeToString(), providers=["CPUExecutionProvider"])
+        for batch_size in (1, 5):
+            other = random_array(batch_size, 1, 12, 12)
+            with marquetry.test_mode():
+                expected = model(other)
+            got = session.run(None, {"input": other})[0]
+            np.testing.assert_allclose(got, expected.data, rtol=1e-4, atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1,0 +1,190 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import onnx
+
+import marquetry
+import marquetry.functions as funcs
+import marquetry.layers as layers
+from marquetry import Model
+from marquetry.models import MLP, Sequential
+from marquetry.onnx_export import export_onnx, ONNXExportError
+from marquetry.onnx_export.exporter import TARGET_IR_VERSION
+
+
+class FuncModel(Model):
+
+    def __init__(self, fn):
+        super().__init__()
+        self._fn = fn
+
+    def forward(self, *inputs):
+        return self._fn(*inputs)
+
+
+def random_array(*shape):
+    return np.random.randn(*shape).astype(np.float32)
+
+
+class TestVersionPinning(unittest.TestCase):
+
+    def test_default_opset_and_ir_version(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+
+        default_domain = [opset for opset in proto.opset_import if opset.domain == ""]
+        self.assertEqual(len(default_domain), 1)
+        self.assertEqual(default_domain[0].version, 21)
+        self.assertEqual(proto.ir_version, TARGET_IR_VERSION)
+
+    def test_custom_opset_version(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5), opset_version=18)
+        self.assertEqual(proto.opset_import[0].version, 18)
+
+    def test_too_old_opset_rejected(self):
+        with self.assertRaises(ValueError):
+            export_onnx(Sequential(layers.Linear(3)), random_array(4, 5), opset_version=17)
+
+    def test_producer_name(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+        self.assertEqual(proto.producer_name, "marquetry")
+
+
+class TestGraphStructure(unittest.TestCase):
+
+    def test_weights_are_initializers_not_inputs(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+
+        input_names = [value_info.name for value_info in proto.graph.input]
+        self.assertEqual(input_names, ["input"])
+
+        initializer_names = {tensor.name for tensor in proto.graph.initializer}
+        self.assertEqual(len(initializer_names), 2)  # weight and bias
+        self.assertFalse(initializer_names & set(input_names))
+
+    def test_no_dropout_node_in_inference_graph(self):
+        model = MLP([8, 4], activation=funcs.relu, is_dropout=True)
+        proto = export_onnx(model, random_array(4, 6))
+
+        op_types = [node.op_type for node in proto.graph.node]
+        self.assertNotIn("Dropout", op_types)
+
+    def test_gemm_used_for_2d_linear(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+        self.assertIn("Gemm", [node.op_type for node in proto.graph.node])
+
+    def test_matmul_used_for_3d_linear(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(2, 4, 5))
+
+        op_types = [node.op_type for node in proto.graph.node]
+        self.assertNotIn("Gemm", op_types)
+        self.assertIn("MatMul", op_types)
+        self.assertIn("Add", op_types)
+
+    def test_output_names_are_unique_ssa(self):
+        model = MLP([8, 8, 4], activation=funcs.relu)
+        proto = export_onnx(model, random_array(4, 6))
+
+        produced = [name for node in proto.graph.node for name in node.output]
+        self.assertEqual(len(produced), len(set(produced)))
+
+    def test_multi_output_graph(self):
+        model = FuncModel(lambda x: tuple(funcs.split(x, 2, axis=1)))
+        proto = export_onnx(model, random_array(4, 6))
+
+        self.assertEqual(len(proto.graph.output), 2)
+        self.assertEqual([out.name for out in proto.graph.output], ["output_0", "output_1"])
+
+    def test_multi_input_graph(self):
+        model = FuncModel(lambda a, b: a + b)
+        proto = export_onnx(model, [random_array(4, 5), random_array(4, 5)])
+
+        self.assertEqual([value_info.name for value_info in proto.graph.input],
+                         ["input_0", "input_1"])
+
+    def test_parameter_names_follow_layer_hierarchy(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+
+        initializer_names = {tensor.name for tensor in proto.graph.initializer}
+        self.assertIn("l0/w", initializer_names)
+        self.assertIn("l0/b", initializer_names)
+
+
+class TestDynamicBatch(unittest.TestCase):
+
+    def test_batch_axis_is_symbolic(self):
+        proto = export_onnx(Sequential(layers.Linear(3)), random_array(4, 5))
+
+        input_dim = proto.graph.input[0].type.tensor_type.shape.dim
+        self.assertEqual(input_dim[0].dim_param, "batch_size")
+        self.assertEqual(input_dim[1].dim_value, 5)
+
+        output_dim = proto.graph.output[0].type.tensor_type.shape.dim
+        self.assertEqual(output_dim[0].dim_param, "batch_size")
+
+    def test_static_batch_when_disabled(self):
+        proto = export_onnx(
+            Sequential(layers.Linear(3)), random_array(4, 5), dynamic_batch=False)
+
+        input_dim = proto.graph.input[0].type.tensor_type.shape.dim
+        self.assertEqual(input_dim[0].dim_value, 4)
+
+
+class TestExportInterface(unittest.TestCase):
+
+    def test_save_to_file_and_reload(self):
+        model = Sequential(layers.Linear(3))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "model.onnx")
+            export_onnx(model, random_array(4, 5), path)
+
+            self.assertTrue(os.path.exists(path))
+            loaded = onnx.load(path)
+            onnx.checker.check_model(loaded)
+
+    def test_model_method(self):
+        model = MLP([8, 4], activation=funcs.relu)
+        proto = model.export_onnx(random_array(4, 6))
+        onnx.checker.check_model(proto)
+
+    def test_custom_io_names(self):
+        proto = export_onnx(
+            Sequential(layers.Linear(3)), random_array(4, 5),
+            input_names=["features"], output_names=["logits"])
+
+        self.assertEqual(proto.graph.input[0].name, "features")
+        self.assertEqual(proto.graph.output[0].name, "logits")
+
+    def test_wrong_io_name_count_rejected(self):
+        with self.assertRaises(ValueError):
+            export_onnx(Sequential(layers.Linear(3)), random_array(4, 5),
+                        input_names=["a", "b"])
+
+    def test_container_sample_input(self):
+        sample = marquetry.array(random_array(4, 5))
+        proto = export_onnx(Sequential(layers.Linear(3)), sample)
+        onnx.checker.check_model(proto)
+
+
+class TestUnsupportedCases(unittest.TestCase):
+
+    def test_unsupported_function_raises_with_name(self):
+        model = FuncModel(lambda x: funcs.repeat(x, 2, 0))
+        with self.assertRaises(ONNXExportError) as raised:
+            export_onnx(model, random_array(4, 5))
+
+        self.assertIn("Repeat", str(raised.exception))
+
+    def test_graphless_model_rejected(self):
+        model = FuncModel(lambda x: marquetry.array(np.zeros((2, 2), dtype=np.float32)))
+        with self.assertRaises(ONNXExportError):
+            export_onnx(model, random_array(4, 5))
+
+    def test_empty_inputs_rejected(self):
+        with self.assertRaises(ValueError):
+            export_onnx(Sequential(layers.Linear(3)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import onnx
+from onnx import numpy_helper
 
 import marquetry
 import marquetry.functions as funcs
@@ -129,6 +130,25 @@ class TestDynamicBatch(unittest.TestCase):
 
         input_dim = proto.graph.input[0].type.tensor_type.shape.dim
         self.assertEqual(input_dim[0].dim_value, 4)
+
+    def test_flatten_reshape_keeps_batch_dynamic(self):
+        model = FuncModel(funcs.flatten)
+        proto = export_onnx(model, random_array(2, 3, 4))
+
+        shape_tensors = [tensor for tensor in proto.graph.initializer
+                         if tensor.name.startswith("reshape_shape")]
+        self.assertEqual(list(numpy_helper.to_array(shape_tensors[0])), [0, -1])
+
+    def test_coincidental_batch_sized_reshape_stays_literal(self):
+        # After the transpose, the leading axis is no longer the batch axis,
+        # so the literal 2 must not be rewritten even though it equals the
+        # traced batch size.
+        model = FuncModel(lambda x: funcs.reshape(funcs.transpose(x), (2, 12)))
+        proto = export_onnx(model, random_array(2, 12))
+
+        shape_tensors = [tensor for tensor in proto.graph.initializer
+                         if tensor.name.startswith("reshape_shape")]
+        self.assertEqual(list(numpy_helper.to_array(shape_tensors[0])), [2, 12])
 
 
 class TestExportInterface(unittest.TestCase):


### PR DESCRIPTION
- Introduced the `marquetry.onnx_export` module with support for ONNX IR export via `export_onnx`.
- Implemented converters for various operations (e.g., math, array manipulation, activations, normalization, pooling, and regularization).
- Added end-to-end tests for ONNX export, validating graph correctness and runtime inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ONNX export: model-level export API and comprehensive ONNX export pipeline with broad operator coverage and export-time options (including a flag to retain graph inputs).

* **Bug Fixes**
  * Preserve dtypes for activations, pooling padding, and parameter initializations for more consistent numeric behavior.

* **Tests / CI**
  * Extensive ONNX export unit and end-to-end tests added; CI installs ONNX and ONNX Runtime for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->