### PR TITLE
Add model archive functionality for saving and loading models in `.mq` format

### DIFF
--- a/marquetry/graph_tracer.py
+++ b/marquetry/graph_tracer.py
@@ -1,0 +1,98 @@
+"""Format-agnostic helpers to trace a model's recorded computation graph.
+
+    The exporters (ONNX, marquetry archive) share the same first step:
+    run one forward pass with sample inputs while the graph is recorded,
+    then walk the creator chain backwards from the outputs.
+    This module hosts that machinery without depending on any export format.
+"""
+import marquetry
+
+
+def normalize_sample_inputs(inputs):
+    """Convert user-provided sample inputs into a list of data-holding containers.
+
+        Args:
+            inputs: A sample input array (or :class:`marquetry.Container`), or a
+                tuple/list of them for multi-input models.
+
+        Returns:
+            list of marquetry.Container: The validated input containers.
+    """
+    input_list = list(inputs) if isinstance(inputs, (tuple, list)) else [inputs]
+    if not input_list:
+        raise ValueError("at least one sample input is needed to trace the model.")
+
+    input_containers = []
+    for sample in input_list:
+        container = marquetry.as_container(sample)
+        if container.data is None:
+            raise ValueError("sample inputs should hold data, but got an empty container.")
+        input_containers.append(container)
+
+    return input_containers
+
+
+def trace_forward(model, input_containers):
+    """Run one forward pass recording the full graph in inference behavior.
+
+        The pass runs in test mode (inference behavior for dropout, batch norm, ...)
+        with back-propagation recording enabled, and every function input retained
+        so that constants stay readable from the traced graph.
+
+        Returns:
+            tuple of marquetry.Container: The model outputs.
+    """
+    with marquetry.using_config("train", False):
+        with marquetry.using_config("enable_backprop", True):
+            with marquetry.using_config("retain_graph_inputs", True):
+                outputs = model(*input_containers)
+
+    return tuple(outputs) if isinstance(outputs, (tuple, list)) else (outputs,)
+
+
+def topological_functions(outputs):
+    """Collect every function reachable from the outputs in executable order.
+
+        Returns:
+            list of marquetry.Function: Traced functions sorted topologically.
+    """
+    functions = []
+    seen = set()
+
+    stack = [output.creator for output in outputs if output.creator is not None]
+    while stack:
+        function = stack.pop()
+        if function in seen:
+            continue
+        seen.add(function)
+        functions.append(function)
+
+        for in_node in function.inputs:
+            if in_node.creator is not None:
+                stack.append(in_node.creator)
+
+    # The generation number strictly increases along every edge,
+    # so sorting by it yields a valid topological (executable) order.
+    functions.sort(key=lambda recorded: recorded.generation)
+
+    return functions
+
+
+def build_parameter_lookup(model):
+    """Map the node identity of every model parameter to its hierarchical name.
+
+        Returns:
+            dict: ``id(parameter.node)`` -> ``(name, data)`` for parameters with data.
+    """
+    lookup = {}
+    if not hasattr(model, "_flatten_params"):
+        return lookup
+
+    params_dict = {}
+    model._flatten_params(params_dict)
+    for key, param in params_dict.items():
+        if param is None or param.data is None:
+            continue
+        lookup[id(param.node)] = (key, param.data)
+
+    return lookup

--- a/marquetry/model.py
+++ b/marquetry/model.py
@@ -36,3 +36,20 @@ class Model(Layer):
         from marquetry.onnx_export import export_onnx
 
         return export_onnx(self, inputs, file_path, **kwargs)
+
+    def export_archive(self, inputs, file_path, **kwargs):
+        """Save this model as a marquetry archive (graph + weights, ``.mq``).
+
+            Unlike :meth:`Layer.save_params` (weights only), the archive stores the
+            traced computation graph as well, so it can be loaded with
+            :func:`marquetry.model_archive.load_archive` and executed (or trained
+            further) without the original model class.
+
+            Args:
+                inputs: A sample input array (or :class:`marquetry.Container`),
+                    or a tuple/list of them for multi-input models.
+                file_path (str): Destination path. ``.mq`` is the recommended extension.
+        """
+        from marquetry.model_archive import save_archive
+
+        return save_archive(self, inputs, file_path, **kwargs)

--- a/marquetry/model_archive/__init__.py
+++ b/marquetry/model_archive/__init__.py
@@ -1,0 +1,5 @@
+from marquetry.model_archive.spec import ArchiveError
+from marquetry.model_archive.spec import FORMAT_VERSION
+from marquetry.model_archive.serializer import save_archive
+from marquetry.model_archive.loader import load_archive
+from marquetry.model_archive.loader import GraphModel

--- a/marquetry/model_archive/loader.py
+++ b/marquetry/model_archive/loader.py
@@ -1,0 +1,137 @@
+import io
+import json
+import zipfile
+
+import numpy as np
+
+import marquetry
+from marquetry.container import Parameter
+from marquetry.model import Model
+from marquetry.model_archive import spec
+from marquetry.model_archive.spec import ArchiveError
+
+
+def load_archive(file_path):
+    """Load a marquetry archive saved by :func:`save_archive`.
+
+        Args:
+            file_path (str): Path to the archive file.
+
+        Returns:
+            GraphModel: A runnable model which replays the stored graph.
+                Its parameters are trainable :class:`marquetry.Parameter` objects,
+                so the loaded model supports both inference and further training.
+    """
+    try:
+        with zipfile.ZipFile(file_path, "r") as archive:
+            header = json.loads(archive.read(spec.FORMAT_FILE))
+            graph = json.loads(archive.read(spec.GRAPH_FILE))
+            weights_buffer = io.BytesIO(archive.read(spec.WEIGHTS_FILE))
+    except (zipfile.BadZipFile, KeyError) as error:
+        raise ArchiveError(
+            "`{}` is not a marquetry archive: {}".format(file_path, error))
+
+    if header.get("format") != spec.FORMAT_NAME:
+        raise ArchiveError(
+            "`{}` is not a marquetry archive (format: {}).".format(
+                file_path, header.get("format")))
+    if header.get("version") != spec.FORMAT_VERSION:
+        raise ArchiveError(
+            "archive version {} isn't supported by this marquetry "
+            "(supported version: {}).".format(header.get("version"), spec.FORMAT_VERSION))
+
+    npz_file = np.load(weights_buffer)
+    weights = {key: npz_file[key] for key in npz_file.files}
+
+    return GraphModel(graph, weights, name=header.get("model_name"))
+
+
+class GraphModel(Model):
+    """A model reconstructed from a marquetry archive.
+
+        The stored graph is replayed by re-applying the original
+        :mod:`marquetry.functions` classes node by node, so the loaded model
+        behaves like the traced one: backpropagation, train/test mode dispatch
+        (dropout, batch normalization) and parameter updates all work.
+    """
+
+    def __init__(self, graph, weights, name=None):
+        super().__init__()
+
+        self._graph_name = name or "GraphModel"
+        self._input_names = [info["name"] for info in graph["inputs"]]
+        self._output_names = list(graph["outputs"])
+
+        self._parameter_names = []
+        for param_name, npz_key in graph["parameters"].items():
+            setattr(self, param_name, Parameter(weights[npz_key], name=param_name))
+            self._parameter_names.append(param_name)
+
+        self._constants = {const_name: weights[npz_key]
+                           for const_name, npz_key in graph["constants"].items()}
+
+        self._nodes = []
+        for node in graph["nodes"]:
+            function_class = _resolve_function_class(node["op"])
+            attributes = {attr_name: spec.decode_value(value, weights.__getitem__)
+                          for attr_name, value in node["attrs"].items()}
+            needs_batch = any(spec.contains_batch_dim(value)
+                              for value in attributes.values())
+            self._nodes.append((function_class, attributes, needs_batch,
+                                node["inputs"], node["outputs"]))
+
+    def forward(self, *inputs):
+        if len(inputs) != len(self._input_names):
+            raise ValueError(
+                "the model expects {} inputs, but {} were given."
+                .format(len(self._input_names), len(inputs)))
+
+        env = dict(zip(self._input_names, inputs))
+        for param_name in self._parameter_names:
+            env[param_name] = getattr(self, param_name)
+        env.update(self._constants)
+
+        for function_class, attributes, needs_batch, in_names, out_names in self._nodes:
+            # Each call gets a fresh function instance (required for autodiff graph
+            # recording). The attribute dict is shallow-copied: scalars detach while
+            # ndarray state such as batch norm running statistics stays shared so
+            # train-mode updates persist across calls.
+            instance_attributes = dict(attributes)
+            if needs_batch:
+                batch_size = _leading_dim(env[in_names[0]])
+                instance_attributes = {
+                    attr_name: spec.resolve_batch_dim(value, batch_size)
+                    for attr_name, value in instance_attributes.items()}
+
+            function = function_class.__new__(function_class)
+            function.__dict__.update(instance_attributes)
+
+            arguments = [env[in_name] if in_name else None for in_name in in_names]
+            results = function(*arguments)
+            if not isinstance(results, (tuple, list)):
+                results = (results,)
+            for out_name, result in zip(out_names, results):
+                env[out_name] = result
+
+        outputs = tuple(env[out_name] for out_name in self._output_names)
+
+        return outputs if len(outputs) > 1 else outputs[0]
+
+
+def _resolve_function_class(op_name):
+    if op_name not in spec.ATTRIBUTE_SPEC:
+        raise ArchiveError(
+            "operator `{}` isn't supported by this marquetry version.".format(op_name))
+
+    function_class = getattr(marquetry.functions, op_name, None)
+    if function_class is None:
+        raise ArchiveError(
+            "operator `{}` can't be resolved in marquetry.functions.".format(op_name))
+
+    return function_class
+
+
+def _leading_dim(value):
+    data = value.data if isinstance(value, marquetry.Container) else value
+
+    return data.shape[0]

--- a/marquetry/model_archive/serializer.py
+++ b/marquetry/model_archive/serializer.py
@@ -1,0 +1,244 @@
+import io
+import json
+import zipfile
+
+import numpy as np
+
+from marquetry import cuda_backend
+from marquetry import graph_tracer
+from marquetry.model_archive import spec
+from marquetry.model_archive.spec import ArchiveError
+
+
+class _Namer(object):
+    """SSA name table mapping ContainerNode identities to unique tensor names."""
+
+    def __init__(self):
+        self._names = {}
+        self._taken = set()
+        self._counts = {}
+        # id() keys are only stable while the objects live, so hold strong refs.
+        self._keepalive = []
+
+    def fresh(self, hint):
+        hint = hint or "tensor"
+        count = self._counts.get(hint, 0)
+        while True:
+            name = hint if count == 0 else "{}_{}".format(hint, count)
+            count += 1
+            if name not in self._taken:
+                break
+        self._counts[hint] = count
+        self._taken.add(name)
+
+        return name
+
+    def has(self, container_node):
+        return id(container_node) in self._names
+
+    def name_of(self, container_node):
+        return self._names[id(container_node)]
+
+    def assign(self, container_node, hint):
+        name = self.fresh(hint)
+        self._names[id(container_node)] = name
+        self._keepalive.append(container_node)
+
+        return name
+
+    def set(self, container_node, name):
+        if name in self._taken:
+            raise ArchiveError("tensor name `{}` is specified twice.".format(name))
+        self._taken.add(name)
+        self._names[id(container_node)] = name
+        self._keepalive.append(container_node)
+
+
+def save_archive(model, inputs, file_path, *, dynamic_batch=True):
+    """Save a model as a marquetry archive (graph + weights, ``.mq``).
+
+        Runs one forward pass with the sample inputs to record the computation
+        graph, then stores every traced function verbatim (class name and
+        constructor attributes) together with the parameters, so the archive can
+        be loaded and executed without the original model class.
+
+        Args:
+            model (marquetry.Model or marquetry.Layer): The model to save.
+            inputs: A sample input array (or :class:`marquetry.Container`), or a
+                tuple/list of them for multi-input models.
+            file_path (str): Destination path. ``.mq`` is the recommended extension.
+            dynamic_batch (bool): If True, reshape targets whose leading dim follows
+                the batch axis are stored as batch-relative so the loaded model
+                accepts any batch size.
+    """
+    input_containers = graph_tracer.normalize_sample_inputs(inputs)
+    outputs = graph_tracer.trace_forward(model, input_containers)
+    parameter_lookup = graph_tracer.build_parameter_lookup(model)
+
+    functions = graph_tracer.topological_functions(outputs)
+
+    namer = _Namer()
+    arrays = {}
+    parameters = {}
+    constants = {}
+
+    first_input = input_containers[0]
+    batch_size = first_input.shape[0] if first_input.ndim >= 1 else None
+
+    input_names = ["input"] if len(input_containers) == 1 else [
+        "input_{}".format(index) for index in range(len(input_containers))]
+    output_names = ["output"] if len(outputs) == 1 else [
+        "output_{}".format(index) for index in range(len(outputs))]
+
+    for container, name in zip(input_containers, input_names):
+        namer.set(container.node, name)
+
+    output_aliases = []
+    for container, name in zip(outputs, output_names):
+        if namer.has(container.node):
+            output_aliases.append((namer.name_of(container.node), name))
+        else:
+            namer.set(container.node, name)
+
+    if not functions and not output_aliases:
+        raise ArchiveError(
+            "no computation graph is recorded from the model outputs. "
+            "The save needs to run under back-propagation enabled mode.")
+
+    nodes = []
+    for function in functions:
+        in_names = [_resolve_input(node, namer, parameter_lookup, arrays,
+                                   parameters, constants)
+                    for node in function.inputs]
+
+        out_names = []
+        for reference in function.outputs:
+            out_node = reference()
+            if out_node is None:
+                out_names.append(namer.fresh("unused"))
+            elif namer.has(out_node):
+                out_names.append(namer.name_of(out_node))
+            else:
+                out_names.append(namer.assign(out_node, function.name.lower() + "_out"))
+
+        nodes.append(_serialize_function(function, in_names, out_names,
+                                         arrays, dynamic_batch, batch_size))
+
+    for source_name, alias_name in output_aliases:
+        namer._taken.add(alias_name)
+        nodes.append({"op": "Identity", "attrs": {},
+                      "inputs": [source_name], "outputs": [alias_name]})
+
+    graph = {
+        "inputs": [_input_info(name, container, dynamic_batch, batch_size)
+                   for name, container in zip(input_names, input_containers)],
+        "outputs": output_names,
+        "parameters": parameters,
+        "constants": constants,
+        "nodes": nodes,
+    }
+
+    header = {
+        "format": spec.FORMAT_NAME,
+        "version": spec.FORMAT_VERSION,
+        "model_name": type(model).__name__,
+    }
+
+    weights_buffer = io.BytesIO()
+    np.savez_compressed(weights_buffer, **arrays)
+
+    with zipfile.ZipFile(file_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(spec.FORMAT_FILE, json.dumps(header, indent=2))
+        archive.writestr(spec.GRAPH_FILE, json.dumps(graph, indent=2))
+        archive.writestr(spec.WEIGHTS_FILE, weights_buffer.getvalue())
+
+
+def _resolve_input(container_node, namer, parameter_lookup, arrays,
+                   parameters, constants):
+    if namer.has(container_node):
+        return namer.name_of(container_node)
+
+    if container_node.creator is not None:
+        raise ArchiveError(
+            "internal error: encountered an input produced by an unvisited function.")
+
+    parameter_entry = parameter_lookup.get(id(container_node))
+    if parameter_entry is not None:
+        key, data = parameter_entry
+        name = namer.assign(container_node, key)
+        arrays[name] = np.ascontiguousarray(cuda_backend.as_numpy(data))
+        parameters[name] = name
+        return name
+
+    if container_node.data is None:
+        # Absent optional input such as an omitted bias.
+        return ""
+
+    name = namer.assign(container_node, "const")
+    arrays[name] = np.ascontiguousarray(cuda_backend.as_numpy(container_node.data))
+    constants[name] = name
+
+    return name
+
+
+def _serialize_function(function, in_names, out_names, arrays,
+                        dynamic_batch, batch_size):
+    op_name = function.__class__.__name__
+    attribute_names = spec.ATTRIBUTE_SPEC.get(op_name)
+    if attribute_names is None:
+        raise ArchiveError(
+            "`{}` can't be stored in a marquetry archive. "
+            "Please replace it or save without this computation.".format(op_name))
+
+    attributes = {name: getattr(function, name) for name in attribute_names}
+
+    if op_name == "Reshape":
+        attributes["shape"] = _mark_batch_dim(
+            attributes["shape"], function.x_shape, dynamic_batch, batch_size)
+
+    tensor_counter = [len(arrays)]
+
+    def add_tensor(array):
+        key = "__tensor__/{}".format(tensor_counter[0])
+        tensor_counter[0] += 1
+        arrays[key] = np.ascontiguousarray(cuda_backend.as_numpy(array))
+        return key
+
+    encoded = {name: spec.encode_value(value, add_tensor)
+               for name, value in attributes.items()}
+
+    return {"op": op_name, "attrs": encoded,
+            "inputs": in_names, "outputs": out_names}
+
+
+def _mark_batch_dim(shape, x_shape, dynamic_batch, batch_size):
+    """Mark a reshape target's leading dim as batch-relative when it tracks the batch.
+
+        Mirrors the ONNX exporter heuristic: substitute only when both the traced
+        input and the target keep the batch extent in front (e.g. flatten's
+        ``(batch, -1)``).
+    """
+    if not dynamic_batch or batch_size is None:
+        return shape
+    if not isinstance(shape, (tuple, list)) or not shape:
+        return shape
+    if shape[0] != batch_size:
+        return shape
+    if x_shape is None or len(x_shape) < 1 or x_shape[0] != batch_size:
+        return shape
+
+    return (spec.BATCH_DIM,) + tuple(shape[1:])
+
+
+def _input_info(name, container, dynamic_batch, batch_size):
+    data = cuda_backend.as_numpy(container.data)
+    info = {
+        "name": name,
+        "dtype": str(data.dtype),
+        "shape": [int(dim) for dim in data.shape],
+    }
+    if dynamic_batch and data.ndim >= 1 and batch_size is not None \
+            and data.shape[0] == batch_size:
+        info["batch_axis"] = 0
+
+    return info

--- a/marquetry/model_archive/serializer.py
+++ b/marquetry/model_archive/serializer.py
@@ -102,8 +102,8 @@ def save_archive(model, inputs, file_path, *, dynamic_batch=True):
 
     if not functions and not output_aliases:
         raise ArchiveError(
-            "no computation graph is recorded from the model outputs. "
-            "The save needs to run under back-propagation enabled mode.")
+            "no computation graph was recorded from the model outputs. "
+            "The outputs must be produced by marquetry functions applied to the sample inputs.")
 
     nodes = []
     for function in functions:

--- a/marquetry/model_archive/spec.py
+++ b/marquetry/model_archive/spec.py
@@ -1,0 +1,183 @@
+"""Format definition of the marquetry model archive.
+
+    A marquetry archive (recommended extension: ``.mq``) is a zip file:
+
+    .. code-block:: text
+
+        model.mq
+        ├── format.json    # format name / version metadata
+        ├── graph.json     # traced computation graph (operator names + attributes)
+        └── weights.npz    # parameters, captured constants and tensor attributes
+
+    The graph stores each traced :class:`marquetry.Function` verbatim
+    (class name plus the constructor attributes listed in ``ATTRIBUTE_SPEC``),
+    so loading a graph re-applies the original marquetry functions
+    without any semantic translation.
+"""
+import numpy as np
+
+
+FORMAT_NAME = "marquetry_archive"
+FORMAT_VERSION = 1
+
+FORMAT_FILE = "format.json"
+GRAPH_FILE = "graph.json"
+WEIGHTS_FILE = "weights.npz"
+
+
+class ArchiveError(RuntimeError):
+    """Raised when a model can't be saved to or loaded from a marquetry archive."""
+
+
+# Constructor attributes to serialize for every supported function class.
+# Runtime caches (masks, saved activations, ...) are deliberately excluded:
+# they are (re)computed by ``forward``.
+ATTRIBUTE_SPEC = {
+    # math
+    "Add": (), "Sub": (), "Mul": (), "Div": (), "Neg": (),
+    "Pow": ("c",),
+    "Absolute": (), "Square": (),
+    "Sqrt": ("eps",),
+    "Reciprocal": ("dtype",),
+    "Exp": (), "Log": (), "Log2": (), "Log10": (),
+    "Clip": ("x_min", "x_max"),
+    "MatMul": (),
+    "Sum": ("axis", "keepdims"),
+    "Max": ("axis", "keepdims"),
+    "Min": ("axis", "keepdims"),
+    "Average": ("axis", "keepdims"),
+    "SumTo": ("shape",),
+    "BroadcastTo": ("shape",),
+
+    # array
+    "Reshape": ("shape",),
+    "Transpose": ("axes",),
+    "Concat": ("axis",),
+    "Squeeze": ("axis",),
+    "UnSqueeze": ("axis",),
+    "Split": ("indices", "axis"),
+    "GetItem": ("slices",),
+    "Repeat": ("repeats", "axis"),
+
+    # connection
+    "Linear": (),
+    "Convolution2D": ("stride", "pad"),
+    "Deconvolution2D": ("stride", "pad", "out_size"),
+
+    # pooling
+    "MaxPooling2D": ("kernel_size", "stride", "pad"),
+
+    # normalization
+    "BatchNormalization": ("avg_mean", "avg_var", "decay", "eps"),
+    "LayerNormalization": ("eps",),
+    "L2Normalization": ("eps", "axis"),
+
+    # activations
+    "ReLU": (), "Sigmoid": (), "Tanh": (), "Mish": (), "Identity": (),
+    "LeakyReLU": ("slope",),
+    "Softmax": ("axis",),
+    "LogSoftmax": ("axis",),
+    "Softplus": ("beta",),
+    "GELU": ("approximate",),
+    "GLU": ("axis",),
+    "PReLU": (),
+    "Swish": ("beta",),
+    "DynamicSwish": (),
+
+    # regularization
+    "Dropout": ("dropout_rate",),
+}
+
+
+class _BatchDim(object):
+    """Sentinel marking a dimension that follows the runtime batch size."""
+
+    def __repr__(self):
+        return "BATCH_DIM"
+
+
+BATCH_DIM = _BatchDim()
+
+
+def encode_value(value, add_tensor):
+    """Encode an attribute value into a JSON-serializable structure.
+
+        Args:
+            value: The attribute value taken from a traced function.
+            add_tensor (callable): Stores an ndarray and returns its npz key.
+
+        Returns:
+            A JSON-serializable representation of the value.
+    """
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if value is BATCH_DIM:
+        return {"$batch_dim": True}
+    if isinstance(value, tuple):
+        return {"$tuple": [encode_value(item, add_tensor) for item in value]}
+    if isinstance(value, list):
+        return [encode_value(item, add_tensor) for item in value]
+    if isinstance(value, slice):
+        return {"$slice": [encode_value(part, add_tensor)
+                           for part in (value.start, value.stop, value.step)]}
+    if isinstance(value, np.ndarray):
+        return {"$tensor": add_tensor(value)}
+
+    raise ArchiveError(
+        "attribute value of type `{}` can't be stored in a marquetry archive."
+        .format(type(value).__name__))
+
+
+def decode_value(value, get_tensor):
+    """Decode a structure produced by :func:`encode_value`.
+
+        Args:
+            value: The JSON-decoded structure.
+            get_tensor (callable): Resolves an npz key to its ndarray.
+
+        Returns:
+            The restored attribute value.
+    """
+    if isinstance(value, list):
+        return [decode_value(item, get_tensor) for item in value]
+    if isinstance(value, dict):
+        if "$tuple" in value:
+            return tuple(decode_value(item, get_tensor) for item in value["$tuple"])
+        if "$slice" in value:
+            start, stop, step = (decode_value(part, get_tensor) for part in value["$slice"])
+            return slice(start, stop, step)
+        if "$tensor" in value:
+            return get_tensor(value["$tensor"])
+        if "$batch_dim" in value:
+            return BATCH_DIM
+        raise ArchiveError("unknown encoded value: {}".format(value))
+
+    return value
+
+
+def contains_batch_dim(value):
+    """Check whether a decoded attribute value contains the batch sentinel."""
+    if value is BATCH_DIM:
+        return True
+    if isinstance(value, (tuple, list)):
+        return any(contains_batch_dim(item) for item in value)
+
+    return False
+
+
+def resolve_batch_dim(value, batch_size):
+    """Replace every batch sentinel in a decoded attribute value with ``batch_size``."""
+    if value is BATCH_DIM:
+        return batch_size
+    if isinstance(value, tuple):
+        return tuple(resolve_batch_dim(item, batch_size) for item in value)
+    if isinstance(value, list):
+        return [resolve_batch_dim(item, batch_size) for item in value]
+
+    return value

--- a/marquetry/model_archive/spec.py
+++ b/marquetry/model_archive/spec.py
@@ -165,6 +165,9 @@ def contains_batch_dim(value):
     """Check whether a decoded attribute value contains the batch sentinel."""
     if value is BATCH_DIM:
         return True
+    if isinstance(value, slice):
+        return any(contains_batch_dim(part)
+                   for part in (value.start, value.stop, value.step))
     if isinstance(value, (tuple, list)):
         return any(contains_batch_dim(item) for item in value)
 
@@ -175,6 +178,10 @@ def resolve_batch_dim(value, batch_size):
     """Replace every batch sentinel in a decoded attribute value with ``batch_size``."""
     if value is BATCH_DIM:
         return batch_size
+    if isinstance(value, slice):
+        return slice(resolve_batch_dim(value.start, batch_size),
+                     resolve_batch_dim(value.stop, batch_size),
+                     resolve_batch_dim(value.step, batch_size))
     if isinstance(value, tuple):
         return tuple(resolve_batch_dim(item, batch_size) for item in value)
     if isinstance(value, list):

--- a/marquetry/onnx_export/exporter.py
+++ b/marquetry/onnx_export/exporter.py
@@ -6,6 +6,7 @@ from onnx import numpy_helper
 
 import marquetry
 from marquetry import cuda_backend
+from marquetry import graph_tracer
 from marquetry.onnx_export import converters
 from marquetry.onnx_export.converters import ONNXExportError
 
@@ -128,22 +129,8 @@ def export_onnx(model, inputs, file_path=None, *, opset_version=DEFAULT_OPSET_VE
             "opset_version {} isn't supported by the installed onnx package (max: {})."
             .format(opset_version, onnx.defs.onnx_opset_version()))
 
-    input_list = list(inputs) if isinstance(inputs, (tuple, list)) else [inputs]
-    if not input_list:
-        raise ValueError("at least one sample input is needed to trace the model.")
-
-    input_containers = []
-    for sample in input_list:
-        container = marquetry.as_container(sample)
-        if container.data is None:
-            raise ValueError("sample inputs should hold data, but got an empty container.")
-        input_containers.append(container)
-
-    with marquetry.using_config("train", False):
-        with marquetry.using_config("enable_backprop", True):
-            with marquetry.using_config("retain_graph_inputs", True):
-                outputs = model(*input_containers)
-    outputs = tuple(outputs) if isinstance(outputs, (tuple, list)) else (outputs,)
+    input_containers = graph_tracer.normalize_sample_inputs(inputs)
+    outputs = graph_tracer.trace_forward(model, input_containers)
 
     first_input = input_containers[0]
     batch_size = first_input.shape[0] if first_input.ndim >= 1 else None
@@ -164,9 +151,9 @@ def export_onnx(model, inputs, file_path=None, *, opset_version=DEFAULT_OPSET_VE
         else:
             context.set_name(container.node, name)
 
-    parameter_lookup = _build_parameter_lookup(model)
+    parameter_lookup = graph_tracer.build_parameter_lookup(model)
 
-    functions = _topological_functions(outputs)
+    functions = graph_tracer.topological_functions(outputs)
     if not functions and not output_aliases:
         raise ONNXExportError(
             "no computation graph is recorded from the model outputs. "
@@ -237,44 +224,6 @@ def _default_io_names(names, count, prefix):
             "{} names are needed for {} tensors, but got {}.".format(prefix, count, len(names)))
 
     return names
-
-
-def _build_parameter_lookup(model):
-    lookup = {}
-    if not hasattr(model, "_flatten_params"):
-        return lookup
-
-    params_dict = {}
-    model._flatten_params(params_dict)
-    for key, param in params_dict.items():
-        if param is None or param.data is None:
-            continue
-        lookup[id(param.node)] = (key, param.data)
-
-    return lookup
-
-
-def _topological_functions(outputs):
-    functions = []
-    seen = set()
-
-    stack = [output.creator for output in outputs if output.creator is not None]
-    while stack:
-        function = stack.pop()
-        if function in seen:
-            continue
-        seen.add(function)
-        functions.append(function)
-
-        for in_node in function.inputs:
-            if in_node.creator is not None:
-                stack.append(in_node.creator)
-
-    # The generation number strictly increases along every edge,
-    # so sorting by it yields a valid topological (executable) order.
-    functions.sort(key=lambda recorded: recorded.generation)
-
-    return functions
 
 
 def _resolve_input_name(container_node, context, parameter_lookup):

--- a/marquetry/onnx_export/exporter.py
+++ b/marquetry/onnx_export/exporter.py
@@ -156,8 +156,8 @@ def export_onnx(model, inputs, file_path=None, *, opset_version=DEFAULT_OPSET_VE
     functions = graph_tracer.topological_functions(outputs)
     if not functions and not output_aliases:
         raise ONNXExportError(
-            "no computation graph is recorded from the model outputs. "
-            "The export needs to run under back-propagation enabled mode.")
+            "no computation graph was recorded from the model outputs. "
+            "The outputs must be produced by marquetry functions applied to the sample inputs.")
 
     for function in functions:
         in_names = [_resolve_input_name(node, context, parameter_lookup)

--- a/tests/test_model_archive.py
+++ b/tests/test_model_archive.py
@@ -1,0 +1,312 @@
+import json
+import os
+import tempfile
+import unittest
+import zipfile
+
+import numpy as np
+
+import marquetry
+import marquetry.functions as funcs
+import marquetry.layers as layers
+from marquetry import Model, optimizers
+from marquetry.models import CNN, MLP, Sequential
+from marquetry.model_archive import (
+    ArchiveError, FORMAT_VERSION, GraphModel, load_archive, save_archive)
+
+
+class FuncModel(Model):
+
+    def __init__(self, fn):
+        super().__init__()
+        self._fn = fn
+
+    def forward(self, *inputs):
+        return self._fn(*inputs)
+
+
+def random_array(*shape):
+    return np.random.randn(*shape).astype(np.float32)
+
+
+def roundtrip(model, inputs, **save_kwargs):
+    """Save the model to a temporary archive and load it back."""
+    if not isinstance(inputs, (tuple, list)):
+        inputs = [inputs]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, "model.mq")
+        save_archive(model, inputs, path, **save_kwargs)
+        restored = load_archive(path)
+
+    return restored
+
+
+def assert_roundtrip(testcase, model, inputs):
+    """The restored graph replays the same functions, so outputs match exactly."""
+    if not isinstance(inputs, (tuple, list)):
+        inputs = [inputs]
+
+    with marquetry.test_mode():
+        expected = model(*[marquetry.as_container(np.copy(x)) for x in inputs])
+    expected = expected if isinstance(expected, tuple) else (expected,)
+
+    restored = roundtrip(model, [np.copy(x) for x in inputs])
+
+    with marquetry.test_mode():
+        actual = restored(*inputs)
+    actual = actual if isinstance(actual, tuple) else (actual,)
+
+    testcase.assertEqual(len(actual), len(expected))
+    for got, exp in zip(actual, expected):
+        np.testing.assert_array_equal(got.data, exp.data)
+
+    return restored
+
+
+class TestOperatorRoundTrip(unittest.TestCase):
+
+    def test_linear(self):
+        assert_roundtrip(self, Sequential(layers.Linear(7)), random_array(4, 3))
+
+    def test_linear_without_bias(self):
+        assert_roundtrip(self, Sequential(layers.Linear(7, nobias=True)), random_array(4, 3))
+
+    def test_convolution(self):
+        assert_roundtrip(
+            self, Sequential(layers.Convolution2D(4, (3, 3), stride=2, pad=1)),
+            random_array(2, 3, 9, 9))
+
+    def test_deconvolution(self):
+        assert_roundtrip(
+            self, Sequential(layers.Deconvolution2D(4, (3, 3), stride=2, pad=1)),
+            random_array(2, 3, 5, 5))
+
+    def test_max_pooling_with_pad(self):
+        assert_roundtrip(
+            self, FuncModel(lambda x: funcs.max_pooling_2d(x, (3, 3), stride=2, pad=1)),
+            random_array(2, 3, 7, 7) - 5.0)
+
+    def test_batch_normalization_with_trained_stats(self):
+        model = Sequential(layers.BatchNormalization())
+        for _ in range(3):
+            model(random_array(8, 5) * 2.0 + 1.0)
+        assert_roundtrip(self, model, random_array(4, 5))
+
+    def test_layer_normalization(self):
+        assert_roundtrip(self, Sequential(layers.LayerNormalization()), random_array(4, 6))
+
+    def test_l2_normalization(self):
+        assert_roundtrip(
+            self, FuncModel(lambda x: funcs.l2_normalization(x, axis=1)), random_array(4, 6))
+
+    def test_activations(self):
+        assert_roundtrip(
+            self,
+            FuncModel(lambda x: funcs.swish(funcs.gelu(funcs.relu(x), approximate="sigmoid"),
+                                            beta=2.0)),
+            random_array(4, 6))
+
+    def test_prelu_layer(self):
+        assert_roundtrip(
+            self, Sequential(layers.PReLU(num_parameter=3, init=0.3)),
+            random_array(2, 3, 5, 5))
+
+    def test_glu(self):
+        assert_roundtrip(self, FuncModel(funcs.glu), random_array(4, 6))
+
+    def test_scalar_constant_is_captured(self):
+        assert_roundtrip(self, FuncModel(lambda x: (x + 2.0) * 0.5), random_array(4, 5))
+
+    def test_math_chain(self):
+        assert_roundtrip(
+            self,
+            FuncModel(lambda x: funcs.clip(x ** 3, -0.5, 0.5) / (funcs.exp(-x) + 2.0)),
+            random_array(4, 5))
+
+    def test_reductions(self):
+        assert_roundtrip(
+            self,
+            FuncModel(lambda x: funcs.sum(x, axis=1, keepdims=True)
+                      + funcs.mean(x, axis=1, keepdims=True)),
+            random_array(3, 4))
+
+    def test_array_operations(self):
+        assert_roundtrip(
+            self,
+            FuncModel(lambda x: funcs.concat(
+                (funcs.transpose(x, (1, 0, 2)), funcs.transpose(x, (1, 0, 2))), axis=2)),
+            random_array(2, 3, 4))
+
+    def test_repeat_unsupported_by_onnx_works_here(self):
+        assert_roundtrip(self, FuncModel(lambda x: funcs.repeat(x, 2, 0)), random_array(3, 4))
+
+    def test_get_item(self):
+        assert_roundtrip(self, FuncModel(lambda x: x[:, 1:3]), random_array(4, 5))
+        assert_roundtrip(self, FuncModel(lambda x: x[1]), random_array(4, 5))
+        assert_roundtrip(self, FuncModel(lambda x: x[::2]), random_array(5, 4))
+
+    def test_split_multi_output(self):
+        assert_roundtrip(
+            self, FuncModel(lambda x: tuple(funcs.split(x, 2, axis=1))), random_array(4, 6))
+
+    def test_multi_input(self):
+        assert_roundtrip(
+            self, FuncModel(lambda a, b: funcs.matmul(a, b) + 1.0),
+            [random_array(4, 5), random_array(5, 3)])
+
+    def test_dropout_traces_and_replays(self):
+        assert_roundtrip(self, FuncModel(lambda x: funcs.dropout(x, 0.5)), random_array(4, 5))
+
+
+class TestModelRoundTrip(unittest.TestCase):
+
+    def test_mlp(self):
+        model = MLP([16, 8], activation=funcs.relu, is_dropout=True)
+        assert_roundtrip(self, model, random_array(4, 12))
+
+    def test_cnn(self):
+        assert_roundtrip(self, CNN(10), random_array(2, 1, 12, 12))
+
+    def test_sequential_mixed(self):
+        model = Sequential(
+            layers.Convolution2D(4, (3, 3), pad=1),
+            layers.BatchNormalization(),
+            funcs.relu,
+            funcs.flatten,
+            layers.Linear(5),
+        )
+        model(random_array(4, 3, 6, 6))  # one train-mode pass to give BN real statistics
+        assert_roundtrip(self, model, random_array(2, 3, 6, 6))
+
+    def test_dynamic_batch(self):
+        model = CNN(7)
+        restored = assert_roundtrip(self, model, random_array(2, 1, 12, 12))
+
+        for batch_size in (1, 5):
+            other = random_array(batch_size, 1, 12, 12)
+            with marquetry.test_mode():
+                expected = model(other)
+                actual = restored(other)
+            np.testing.assert_array_equal(actual.data, expected.data)
+
+    def test_static_batch_keeps_literal_reshape(self):
+        model = CNN(7)
+        restored = roundtrip(model, random_array(2, 1, 12, 12), dynamic_batch=False)
+
+        with marquetry.test_mode():
+            restored(random_array(2, 1, 12, 12))  # traced batch size still works
+            with self.assertRaises(ValueError):
+                restored(random_array(3, 1, 12, 12))
+
+
+class TestRestoredModelBehavior(unittest.TestCase):
+
+    def test_parameters_are_trainable(self):
+        restored = roundtrip(MLP([8, 4], activation=funcs.relu, is_dropout=False),
+                             random_array(4, 6))
+
+        params_before = {id(p): np.copy(p.data) for p in restored.params()}
+        self.assertTrue(params_before)
+
+        optimizer = optimizers.Adam().prepare(restored)
+        x = random_array(16, 6)
+        t = np.random.randint(0, 4, size=16)
+
+        y = restored(x)
+        loss = funcs.softmax_cross_entropy(y, t)
+        restored.clear_grads()
+        loss.backward()
+        optimizer.update()
+
+        changed = [not np.array_equal(params_before[id(p)], p.data)
+                   for p in restored.params()]
+        self.assertTrue(all(changed))
+
+    def test_train_test_mode_dispatch_is_preserved(self):
+        restored = roundtrip(FuncModel(lambda x: funcs.dropout(x, 0.5)), random_array(4, 6))
+        x = np.ones((64, 16), dtype=np.float32)
+
+        with marquetry.test_mode():
+            test_out = restored(x).data
+        np.testing.assert_array_equal(test_out, x)
+
+        train_out = restored(x).data  # train mode: dropout randomly zeroes entries
+        self.assertTrue((train_out == 0.0).any())
+
+    def test_save_params_keys_match_original(self):
+        model = MLP([8, 4], activation=funcs.relu)
+        model(random_array(2, 6))  # initialize the lazy weights
+        restored = roundtrip(model, random_array(2, 6))
+
+        original_params, restored_params = {}, {}
+        model._flatten_params(original_params)
+        restored._flatten_params(restored_params)
+
+        original_keys = {key for key, param in original_params.items() if param is not None}
+        self.assertEqual(original_keys, set(restored_params.keys()))
+
+
+class TestArchiveFile(unittest.TestCase):
+
+    def test_archive_is_a_zip_with_expected_members(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "model.mq")
+            save_archive(Sequential(layers.Linear(3)), random_array(4, 5), path)
+
+            with zipfile.ZipFile(path) as archive:
+                members = set(archive.namelist())
+                self.assertEqual(members, {"format.json", "graph.json", "weights.npz"})
+
+                header = json.loads(archive.read("format.json"))
+                self.assertEqual(header["format"], "marquetry_archive")
+                self.assertEqual(header["version"], FORMAT_VERSION)
+
+                graph = json.loads(archive.read("graph.json"))
+                self.assertEqual([node["op"] for node in graph["nodes"]], ["Linear"])
+                self.assertEqual(len(graph["parameters"]), 2)
+
+    def test_load_returns_graph_model(self):
+        restored = roundtrip(Sequential(layers.Linear(3)), random_array(4, 5))
+        self.assertIsInstance(restored, GraphModel)
+        self.assertIsInstance(restored, Model)
+
+    def test_unsupported_function_raises_with_name(self):
+        model = FuncModel(lambda x: funcs.softmax_cross_entropy(x, np.array([0, 1])))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "model.mq")
+            with self.assertRaises(ArchiveError) as raised:
+                save_archive(model, random_array(2, 3), path)
+
+        self.assertIn("SoftmaxCrossEntropy", str(raised.exception))
+
+    def test_future_version_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "model.mq")
+            save_archive(Sequential(layers.Linear(3)), random_array(4, 5), path)
+
+            tampered = os.path.join(tmp_dir, "tampered.mq")
+            with zipfile.ZipFile(path) as source, zipfile.ZipFile(tampered, "w") as target:
+                for member in source.namelist():
+                    payload = source.read(member)
+                    if member == "format.json":
+                        header = json.loads(payload)
+                        header["version"] = FORMAT_VERSION + 999
+                        payload = json.dumps(header)
+                    target.writestr(member, payload)
+
+            with self.assertRaises(ArchiveError):
+                load_archive(tampered)
+
+    def test_not_an_archive_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "not_archive.mq")
+            with open(path, "wb") as f:
+                f.write(b"not a zip at all")
+
+            with self.assertRaises(ArchiveError):
+                load_archive(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_archive.py
+++ b/tests/test_model_archive.py
@@ -203,6 +203,9 @@ class TestModelRoundTrip(unittest.TestCase):
 class TestRestoredModelBehavior(unittest.TestCase):
 
     def test_parameters_are_trainable(self):
+        # Deterministic data: with a fixed seed, every parameter tensor receives a
+        # non-zero gradient, so asserting that all of them change is stable.
+        np.random.seed(0)
         restored = roundtrip(MLP([8, 4], activation=funcs.relu, is_dropout=False),
                              random_array(4, 6))
 
@@ -297,6 +300,13 @@ class TestArchiveFile(unittest.TestCase):
 
             with self.assertRaises(ArchiveError):
                 load_archive(tampered)
+
+    def test_batch_dim_detected_and_resolved_inside_slice(self):
+        from marquetry.model_archive import spec
+
+        value = (slice(spec.BATCH_DIM, None, None), 3)
+        self.assertTrue(spec.contains_batch_dim(value))
+        self.assertEqual(spec.resolve_batch_dim(value, 8), (slice(8, None, None), 3))
 
     def test_not_an_archive_rejected(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
- Implemented `save_archive` and `load_archive` utilities to store and retrieve models with computation graphs and parameters.
- Added `GraphModel` for reconstructing and executing stored graphs.
- Introduced tests validating model roundtrip behavior for various layers, functions, activations, and advanced use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models can be exported to a .mq archive (graph + weights) via Model.export_archive().
  * Archives can be loaded and executed as standalone GraphModel instances (no original source required).
  * Export supports dynamic-batch semantics for flexible batch sizes.
  * Top-level archive APIs (save/load) are now accessible from the model_archive package.

* **Tests**
  * Added comprehensive round‑trip tests validating archive correctness, replay fidelity, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->