### PR TITLE
Add GitHub release workflow to automate version tagging and release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,36 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+
+  github-release:
+    name: Create GitHub release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      # to push the version tag and create the release
+      contents: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Resolve released version
+        id: version
+        run: |
+          wheel=$(ls dist/*.whl | head -n 1)
+          version=$(basename "$wheel" | cut -d- -f2)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Released version: $version"
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,17 +130,30 @@ jobs:
       - name: Resolve released version
         id: version
         run: |
-          wheel=$(ls dist/*.whl | head -n 1)
+          wheel=$(ls dist/*.whl 2>/dev/null | head -n 1)
+          if [ -z "$wheel" ]; then
+            echo "::error::No wheel found in dist/, cannot resolve the released version."
+            exit 1
+          fi
           version=$(basename "$wheel" | cut -d- -f2)
+          if ! echo "$version" | grep -Eq '^[0-9][A-Za-z0-9.+-]*$'; then
+            echo "::error::Resolved version '$version' does not look like a valid version string."
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Released version: $version"
 
       - name: Create tag and release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" dist/* \
+          if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, skipping creation."
+            exit 0
+          fi
+          gh release create "v${VERSION}" dist/* \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
-            --title "v${{ steps.version.outputs.version }}" \
+            --title "v${VERSION}" \
             --generate-notes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now automatically creates a GitHub tag and release after publishing to PyPI, deriving the package version from the built artifact, generating release notes, and skipping creation if a matching release already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->